### PR TITLE
fix(docs): баннер MkDocs + обновление GitHub Actions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,9 +18,9 @@ jobs:
       run:
         working-directory: app/ui
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -34,9 +34,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync to deploy dir
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/birdlense-hub
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./app
           file: ./app/Dockerfile

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -6,6 +6,7 @@ on:
     branches: [main, dev]
     paths:
       - "docs/**"
+      - "overrides/**"
       - "mkdocs.yml"
       - "VERSION"
       - "requirements-docs.txt"
@@ -29,9 +30,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -47,7 +48,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: site
 

--- a/.github/workflows/wiki-report.yml
+++ b/.github/workflows/wiki-report.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate wiki report
         run: |
@@ -29,7 +29,7 @@ jobs:
         run: cat wiki-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wiki-report
           path: wiki-report.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **GitHub Pages:** docs workflow triggers on `VERSION` and `scripts/check-docs-version.py` changes; build is strict.
+- **GitHub Actions:** `actions/checkout@v6`, `setup-python@v6`, `setup-node@v6`, `upload-pages-artifact@v4`, `upload-artifact@v6`, Docker actions (buildx/login/metadata/build-push v4/v4/v6/v7) — актуальные рантаймы, меньше предупреждений про Node.js 20.
 
 ### Fixed
 
-- **Docs (MkDocs strict):** internal links to repo-root files (`.github/`, `scripts/`) and excluded `docs/archive/` now point to GitHub blob URLs so `mkdocs build --strict` passes in CI.
+- **MkDocs:** баннер версии через `overrides/main.html` (`{% block announce %}`): в community Material `theme.announcement` в `mkdocs.yml` не рендерится — баннер был пустым; после деплоя отображается **v** из `extra.site_version`.
+- **Docs (MkDocs strict):** ссылки на корень репозитория и `docs/archive/` — на blob GitHub, чтобы `mkdocs build --strict` проходил в CI.
 
 ---
 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -37,7 +37,7 @@ Build output goes to `site/` (ignored by git).
 Workflow [.github/workflows/docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml):
 
 - On push to **`main`** or **`dev`** when `docs/**`, `mkdocs.yml`, `VERSION`, `requirements-docs.txt`, or `scripts/check-docs-version.py` change (or manually via **Actions → Documentation site → Run workflow**), the site is **built** every run.
-- Before build: **`python3 scripts/check-docs-version.py`** — the string from root **`VERSION`** must appear in `mkdocs.yml` (`theme.announcement` and `extra.site_version`) so the banner cannot drift from releases.
+- Before build: **`python3 scripts/check-docs-version.py`** — the string from root **`VERSION`** must appear in `mkdocs.yml` (at least `extra.site_version`; the top banner is **`overrides/main.html`** → `{% block announce %}` with `config.extra.site_version`).
 - Build: **`mkdocs build --strict`** (broken links / nav issues fail CI).
 - **Deploy to GitHub Pages** runs only for **`main`**.
 

--- a/docs/Documentation.ru.md
+++ b/docs/Documentation.ru.md
@@ -37,7 +37,7 @@ python3 -m venv .venv-docs
 Workflow [.github/workflows/docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml):
 
 - При push в **`main`** или **`dev`** при изменениях в `docs/**`, `mkdocs.yml`, **`VERSION`**, `requirements-docs.txt` или `scripts/check-docs-version.py` (или вручную: **Actions → Documentation site → Run workflow**) сайт **собирается** каждый раз.
-- Перед сборкой: **`python3 scripts/check-docs-version.py`** — строка из корневого **`VERSION`** должна быть в `mkdocs.yml` (`theme.announcement` и `extra.site_version`), чтобы баннер не отставал от релиза.
+- Перед сборкой: **`python3 scripts/check-docs-version.py`** — строка из корневого **`VERSION`** должна быть в `mkdocs.yml` (как минимум `extra.site_version`; верхний баннер — **`overrides/main.html`**, блок `{% block announce %}`, версия из `config.extra.site_version`).
 - Сборка: **`mkdocs build --strict`** (битые ссылки и ошибки навигации роняют CI).
 - **Деплой на GitHub Pages** выполняется только для ветки **`main`**.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -32,7 +32,7 @@ Examples:
 
 Update **all three** on each release.
 
-Also update **`mkdocs.yml`**: `theme.announcement` and `extra.site_version` must contain the same semver string as `VERSION` (CI runs `scripts/check-docs-version.py`).
+Also update **`mkdocs.yml`**: `extra.site_version` must match `VERSION` (CI: `scripts/check-docs-version.py`). The visible banner is rendered from **`overrides/main.html`** (`announce` block), not from a `theme.announcement` key (Material ignores that in YAML).
 
 ---
 

--- a/docs/VERSIONING.ru.md
+++ b/docs/VERSIONING.ru.md
@@ -29,7 +29,7 @@
 
 При релизе обновлять все три.
 
-Также **`mkdocs.yml`**: строка версии в `theme.announcement` и в `extra.site_version` должна совпадать с `VERSION` (проверка в CI: `scripts/check-docs-version.py`).
+Также **`mkdocs.yml`**: `extra.site_version` должен совпадать с `VERSION` (CI: `scripts/check-docs-version.py`). Видимый баннер задаётся в **`overrides/main.html`** (блок `announce`), ключ `theme.announcement` в YAML Material не использует.
 
 ## Релизы и теги
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Static documentation site (MkDocs Material).
 # Source of truth remains Markdown under docs/. Nav mirrors docs/SITE_MAP.md.
-# При релизе: строка версии из VERSION должна встречаться в theme.announcement (проверка scripts/check-docs-version.py).
+# При релизе: VERSION должна встречаться в mkdocs.yml и совпадать с extra.site_version (проверка scripts/check-docs-version.py). Баннер — overrides/main.html.
 site_name: BirdLense Hub
 site_description: Documentation for the BirdLense Hub bird-monitoring stack
 site_url: https://gfermoto.github.io/BirdLense-Hub/
@@ -12,8 +12,7 @@ copyright: Copyright &copy; BirdLense Hub contributors
 
 theme:
   name: material
-  # Видимая версия на сайте (должна совпадать с VERSION в корне репозитория).
-  announcement: 'BirdLense Hub documentation · <strong>v0.2.2</strong> · <a href="https://github.com/Gfermoto/BirdLense-Hub/releases">Releases</a>'
+  custom_dir: overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
@@ -30,6 +29,7 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
+    - announce.dismiss
     - navigation.instant
     - navigation.tracking
     - content.code.copy

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,7 @@
+{#- Announcement bar: Material ignores theme.announcement in mkdocs.yml; official way is this block. Version from extra.site_version (must match root VERSION; see scripts/check-docs-version.py). -#}
+{% extends "base.html" %}
+
+{% block announce %}
+  BirdLense Hub documentation · <strong>v{{ config.extra.site_version }}</strong> ·
+  <a href="https://github.com/Gfermoto/BirdLense-Hub/releases">Releases</a>
+{% endblock %}

--- a/scripts/check-docs-version.py
+++ b/scripts/check-docs-version.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Проверяет, что строка версии из VERSION встречается в mkdocs.yml (баннер сайта)."""
+"""Проверяет, что строка версии из VERSION есть в mkdocs.yml (extra.site_version) для баннера в overrides/main.html."""
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -8,6 +8,6 @@ mk = (ROOT / "mkdocs.yml").read_text(encoding="utf-8")
 if ver not in mk:
     raise SystemExit(
         f"VERSION={ver!r} не найдена в mkdocs.yml. "
-        "Обновите theme.announcement и extra.site_version вместе с релизом (см. docs/VERSIONING.md)."
+        "Обновите extra.site_version в mkdocs.yml и при необходимости VERSIONING (баннер: overrides/main.html)."
     )
 print(f"check-docs-version: OK ({ver} in mkdocs.yml)")


### PR DESCRIPTION
## Изменения
- Баннер версии: `overrides/main.html` (`{% block announce %}`), т.к. `theme.announcement` в community Material не рендерится
- `mkdocs.yml`: `custom_dir`, `announce.dismiss`
- Actions: checkout/setup-python/setup-node v6, upload-pages-artifact v4, upload-artifact v6, Docker actions обновлены
- Доки VERSIONING/Documentation + CHANGELOG

После merge пересоберётся GitHub Pages.

Made with [Cursor](https://cursor.com)