### PR TITLE
fix(ci): чистые GitHub Deployments для Pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,4 +1,4 @@
-# Build MkDocs site and deploy to GitHub Pages (source: GitHub Actions).
+# MkDocs → GitHub Pages. Deploy only from main (tag refs fail github-pages environment rules).
 name: Documentation site
 
 on:
@@ -12,8 +12,6 @@ on:
       - "requirements-docs.txt"
       - "scripts/check-docs-version.py"
       - ".github/workflows/docs-pages.yml"
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -52,7 +50,7 @@ jobs:
           path: site
 
   deploy:
-    if: github.event_name == 'release' || (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: сайт документации — без workflow на `release` (деплой только с `main`), чтобы не было failed deployment в списке при теге.
+
 ---
 
 ## [0.2.3] - 2026-03-20

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -47,7 +47,7 @@ Also update **`mkdocs.yml`**: `extra.site_version` must match `VERSION` (CI: `sc
 ### GitHub Actions after a release
 
 - **Docker:** [docker-publish.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docker-publish.yml) — `main` + **published** Release → `latest` + semver tag.
-- **Docs site:** [docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml) — deploy Pages on `main` (path-filtered pushes), `workflow_dispatch` from `main`, and **published** Release.
+- **Docs site:** [docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml) — deploy Pages только с ветки **`main`** (push по путям или `workflow_dispatch`). После merge релиза этого достаточно; деплой с тега не используется (ограничения окружения `github-pages`).
 
 Wiki (optional): [WIKI_AUTOMATION](./WIKI_AUTOMATION.md).
 

--- a/docs/VERSIONING.ru.md
+++ b/docs/VERSIONING.ru.md
@@ -42,7 +42,7 @@
 ### Что запускает GitHub Actions после релиза
 
 - **Docker:** [docker-publish.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docker-publish.yml) — `main` + **опубликованный** Release → `latest` + semver-тег образа.
-- **Сайт:** [docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml) — деплой Pages при push в `main` (по путям), `workflow_dispatch` с `main` и при **опубликованном** Release.
+- **Сайт:** [docs-pages.yml](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/workflows/docs-pages.yml) — деплой Pages только с **`main`** (push по путям или `workflow_dispatch`). После merge релиза этого достаточно; с тега не деплоим (правила окружения `github-pages`).
 
 Wiki (опционально): [WIKI_AUTOMATION](./WIKI_AUTOMATION.ru.md).
 


### PR DESCRIPTION
Убран trigger `release` у docs-pages: деплой только с `main`, без failed deployment по тегу.

Made with [Cursor](https://cursor.com)