### PR TITLE
fix(deploy): rsync excludes for venv/site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,11 @@ jobs:
             --exclude='app/app_config/user_config.yaml' \
             --exclude='node_modules' \
             --exclude='__pycache__' \
+            --exclude='.venv-docs-tmp' \
+            --exclude='.venv-docs' \
+            --exclude='site' \
+            --exclude='app/.venv' \
+            --exclude='.venv-datasets' \
             ./ "$DEPLOY_DIR"/
 
       - name: Pull and restart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Деплой (`scripts/deploy.sh`): rsync исключает `.venv-docs-tmp`, `.venv-docs`, `site/`, `app/.venv` — не заливать локальные venv на сервер.
 - CI: сайт документации — без workflow на `release` (деплой только с `main`), чтобы не было failed deployment в списке при теге.
 
 ---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,6 +43,9 @@ cd "$(dirname "$0")/.."
 echo "1. Синхронизация кода..."
 RSYNC_EXCLUDES="--exclude=.git --exclude=node_modules --exclude=__pycache__ --exclude=.env"
 RSYNC_EXCLUDES="$RSYNC_EXCLUDES --exclude=app/data --exclude=app/app_config/user_config.yaml --exclude=scripts/deploy.local.sh"
+# Локальные venv / сборка док — не на сервер
+RSYNC_EXCLUDES="$RSYNC_EXCLUDES --exclude=.venv-docs-tmp --exclude=.venv-docs --exclude=site"
+RSYNC_EXCLUDES="$RSYNC_EXCLUDES --exclude=app/.venv --exclude=.venv-datasets"
 sync_ok=0
 for attempt in $(seq 1 ${SYNC_RETRIES}); do
   if [[ "${HOST}" == "localhost" || "${HOST}" == "127.0.0.1" ]]; then


### PR DESCRIPTION
Чтобы локальная `.venv-docs-tmp` и сборка docs не попадали на сервер.

Made with [Cursor](https://cursor.com)