### PR TITLE
docs(roadmap): консилиум бэклога + Issues #46–#57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Roadmap: секция **Backlog consilium (March 2026)** + 12 GitHub Issues [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) для доски Project.
 - CI: workflow `prune-branches.yml` — на `origin` только **`main`** и **`dev`** (только ручной `workflow_dispatch`).
 - `.github/github-social-preview.png` — Open Graph / Social preview для репозитория (1280×640).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,6 +27,29 @@ Direction of travel and current stack. **Shipped items** are summarized here; de
 
 ---
 
+## Backlog consilium (March 2026)
+
+**Brainstorm roles:** product (operator value), security, platform/infra, ML & data, integrations (MQTT/HA/Frigate), UX, docs & OSS hygiene.
+
+**Outcome:** triaged items are **GitHub Issues** (not shipped until closed in a release): [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57). Add them to the repo **Project** board (Backlog / Todo column). If `gh project` fails locally, run `gh auth refresh -s read:project,project` and attach issues in the GitHub UI.
+
+| # | Theme | Issue | Labels (summary) |
+|---|--------|-------|------------------|
+| 1 | Rate limiting for settings / auth API | [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46) | `area:web`, P2 |
+| 2 | Git history secret scan (maintainer) | [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47) | `area:infra`, docs |
+| 3 | `export_birdlense_to_yolo.py` training export | [#48](https://github.com/Gfermoto/BirdLense-Hub/issues/48) | `area:processor`, P2 |
+| 4 | ARM64 Docker spike | [#49](https://github.com/Gfermoto/BirdLense-Hub/issues/49) | `area:infra`, P3 |
+| 5 | MQTT reconnect / missed-events clarity | [#50](https://github.com/Gfermoto/BirdLense-Hub/issues/50) | `area:processor`, P2 |
+| 6 | UI: backup / restore SQLite | [#51](https://github.com/Gfermoto/BirdLense-Hub/issues/51) | `area:web`, P3 |
+| 7 | UI i18n framework | [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52) | `area:web`, P3 |
+| 8 | CI: scheduled image smoke test | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) | `area:infra`, P3 |
+| 9 | CI: OpenAPI contract tests | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) | `area:web`, P3 |
+| 10 | Yearly species checklist / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) | `area:web`, P3 |
+| 11 | CORS demo host → config/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | `area:web`, P3 |
+| 12 | Docs: Prometheus alert examples | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) | `area:docs`, P3 |
+
+---
+
 ## Backlog (ideas)
 
 Roughly ordered **simple → complex**. Many rows are **done** — kept for history; cross-check [FEATURES](./FEATURES.md) before assuming something is missing.

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -31,6 +31,29 @@
 
 ---
 
+## Консилиум по бэклогу (март 2026)
+
+**Роли (мозговой штурм):** продукт/оператор, безопасность, платформа и CI, ML и данные, интеграции (MQTT, HA, Frigate), UX, документация и open-source гигиена.
+
+**Результат:** задачи заведены как **Issues** на GitHub: [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57). Их нужно добавить на **Project**-доску репозитория (колонка Backlog / Todo). Если команда `gh project` ругается на права — выполните `gh auth refresh -s read:project,project` или перенесите issues вручную в веб-интерфейсе GitHub.
+
+| # | Тема | Issue | Приоритет / зона |
+|---|------|-------|------------------|
+| 1 | Rate limit для настроек / auth API | [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46) | P2, web |
+| 2 | Скан истории git на секреты | [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47) | P3, infra |
+| 3 | Скрипт `export_birdlense_to_yolo.py` | [#48](https://github.com/Gfermoto/BirdLense-Hub/issues/48) | P2, processor |
+| 4 | Спайк ARM64 Docker | [#49](https://github.com/Gfermoto/BirdLense-Hub/issues/49) | P3, infra |
+| 5 | Устойчивость MQTT, док по пропускам | [#50](https://github.com/Gfermoto/BirdLense-Hub/issues/50) | P2, processor |
+| 6 | UI: бэкап/восстановление SQLite | [#51](https://github.com/Gfermoto/BirdLense-Hub/issues/51) | P3, web |
+| 7 | i18n в UI | [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52) | P3, web |
+| 8 | CI: периодический smoke образа | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) | P3, infra |
+| 9 | CI: тесты контракта OpenAPI | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) | P3, web |
+| 10 | Чеклист видов за год / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) | P3, web |
+| 11 | CORS demo → конфиг/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | P3, web |
+| 12 | Доки: примеры алертов Prometheus | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) | P3, docs |
+
+---
+
 ## Идеи (backlog)
 
 От простого к сложному:


### PR DESCRIPTION
## Консилиум / бэклог
- В ROADMAP (EN/RU): секция **Backlog consilium (March 2026)** — роли, таблица из 12 тем.
- Созданы Issues **#46–#57** (enhancement/triage + area/priority).

## GitHub Project
Автоматически привязать к доске не удалось: у `gh` нет scope `read:project` / `project`. Добавьте issues на доску вручную или: `gh auth refresh -h github.com -s read:project -s project`.

## Проверки
- `mkdocs build --strict` — OK локально.

Made with [Cursor](https://cursor.com)