### PR TITLE
fix(github): защита main+dev, отключить автоудаление веток после merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- GitHub: `scripts/github-repo-bootstrap.sh` — **без** `--delete-branch-on-merge`, явно `delete_branch_on_merge=false`; защита **`dev`** тем же JSON, что и `main` (`allow_deletions: false`). Доки: [GITHUB_SETUP_GH.ru.md](docs/GITHUB_SETUP_GH.ru.md) §4.
 - Доки: INSTALL ↔ `scripts/deploy.sh` (контейнер `birdlense`, `DEPLOY_REMOTE_DIR`, rsync, Intel override); пример `deploy.local.sh.example` с `DEPLOY_REMOTE_DIR`; SCENARIOS.ru (Grafana) как в EN; OPEN_SOURCE_PREP.ru — актуальный блок про плейсхолдеры; README / I18N_STATUS / SITE_MAP — формулировки под MkDocs; пути клон `BirdLense-Hub` vs каталог на сервере.
 - `app/Makefile`: комментарии деплоя и E2E без захардкоженного LAN IP.
 - GitHub: ruleset **Protect** на default branch — обязательны успешные checks **`ui-build`** и **`docs`** (workflow CI); approvals по-прежнему 0 (solo).

--- a/docs/GITHUB_SETUP_GH.md
+++ b/docs/GITHUB_SETUP_GH.md
@@ -8,7 +8,7 @@ Full Russian walkthrough: **[GITHUB_SETUP_GH.ru.md](./GITHUB_SETUP_GH.ru.md)** (
 ./scripts/github-repo-bootstrap.sh
 ```
 
-Branch protection payload: `scripts/github-branch-protection-main.json`. Ruleset **Protect** also requires CI jobs **`ui-build`** and **`docs`** (0 approvals — solo maintainer); details in the Russian guide.
+Branch protection: use [`scripts/github-branch-protection-main.json`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/scripts/github-branch-protection-main.json) for **both** `main` and `dev` (`allow_deletions: false`). Turn off **Automatically delete head branches** so merging `dev` → `main` does not delete `dev`. Ruleset **Protect** + required checks **`ui-build`** / **`docs`** — see the Russian guide.
 
 Wiki + CI reports: [WIKI_AUTOMATION.md](./WIKI_AUTOMATION.md).
 

--- a/docs/GITHUB_SETUP_GH.ru.md
+++ b/docs/GITHUB_SETUP_GH.ru.md
@@ -114,11 +114,11 @@ gh api -X POST "repos/$FULL/pages" \
 
 ---
 
-## 4. Защита ветки `main` (один мейнтейнер, без второго человека)
+## 4. Защита веток `main` и `dev` (один мейнтейнер, без второго человека)
 
-Цель: **запрет прямого push в `main`**, merge только через **PR** (с `dev` или фича-веток), **без** обязательных approve (пока нет наблюдателя).
+Цель: **запрет прямого push** в `main` и `dev`, merge в `main` только через **PR**; **ветки нельзя удалить** (в т.ч. случайно после merge). **Не включайте** в репозитории опцию *Automatically delete head branches*: при merge PR `dev` → `main` GitHub иначе **удалит `dev`**.
 
-Файл в репозитории: [`scripts/github-branch-protection-main.json`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/scripts/github-branch-protection-main.json).
+Файл в репозитории: [`scripts/github-branch-protection-main.json`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/scripts/github-branch-protection-main.json) — тот же payload для **обеих** веток (`allow_deletions: false`).
 
 Применить:
 
@@ -126,12 +126,20 @@ gh api -X POST "repos/$FULL/pages" \
 cd /path/to/BirdLense-Hub   # корень клона
 gh api --method PUT "repos/$FULL/branches/main/protection" \
   --input scripts/github-branch-protection-main.json
+gh api --method PUT "repos/$FULL/branches/dev/protection" \
+  --input scripts/github-branch-protection-main.json
 ```
 
-Если GitHub вернёт **422** (политика API менялась), откройте **Settings → Rules → Rulesets** и создайте правило для `main`:
+Выключить автоудаление веток после merge (если включалось ранее):
+
+```bash
+gh api "repos/$FULL" -X PATCH -f delete_branch_on_merge=false
+```
+
+Если GitHub вернёт **422** (политика API менялась), откройте **Settings → Rules → Rulesets** и создайте правила для `main` и `dev`:
 
 - запрет удаления / force push;
-- требование **Pull request** перед merge;
+- требование **Pull request** перед merge в `main` (для `dev` — по желанию: можно разрешить прямой push мейнтейнеру, но **запрет удаления** оставить);
 - **Required approvals: 0** до появления второго человека.
 
 Потом добавьте **Required approvals: 1** и второго в [`.github/CODEOWNERS`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/.github/CODEOWNERS).
@@ -183,7 +191,8 @@ gh secret list -R "$FULL"
 
 ## Чеклист после настройки
 
-- [ ] `main` защищён: нет force-push, merge через PR.
+- [ ] `main` и `dev` защищены: нет force-push, **нельзя удалить** ветку; `main` — merge через PR.
+- [ ] **Automatically delete head branches** выключено (или эквивалент: `delete_branch_on_merge=false`), иначе после merge PR из `dev` пропадёт сама `dev`.
 - [ ] Pages: сайт открывается, последний workflow **Documentation site** зелёный на `main`.
 - [ ] Dependabot PR’ы не копятся месяцами.
 - [ ] **Deploy** workflow: либо runner поднят, либо workflow отключён / не required, чтобы не было вечных красных статусов.

--- a/scripts/github-repo-bootstrap.sh
+++ b/scripts/github-repo-bootstrap.sh
@@ -31,7 +31,6 @@ gh repo edit "$FULL" \
   --add-topic "home-assistant" \
   --add-topic "machine-learning" \
   --default-branch main \
-  --delete-branch-on-merge \
   --enable-issues \
   --enable-projects
 
@@ -39,21 +38,31 @@ gh api "repos/${FULL}" -X PATCH -f has_wiki=true >/dev/null \
   && echo "    Wiki: включена (has_wiki=true). Автоотчёты: workflow Wiki report + docs/WIKI_AUTOMATION.ru.md" \
   || echo "    Wiki: не удалось включить через API (включите в Settings → General → Wikis)."
 
+# Не удалять head-ветку после merge: иначе при merge PR dev→main GitHub сотрёт long-lived ветку dev.
+gh api "repos/${FULL}" -X PATCH -f delete_branch_on_merge=false >/dev/null \
+  && echo "    delete_branch_on_merge=false (ветки main и dev не исчезают после PR)" \
+  || echo "    (delete_branch_on_merge: не удалось выставить через API)"
+
 gh repo edit "$FULL" --enable-discussions 2>/dev/null || echo "(discussions: пропуск, если флаг недоступен)"
 
 echo "==> Включение vulnerability alerts (для публичного репо обычно безвредно)"
 gh api -X PUT "repos/${FULL}/vulnerability-alerts" 2>/dev/null || echo "(alerts: уже есть или недоступно для типа репо)"
 
 echo ""
-echo "==> Защита ветки main (PR обязателен, approve: 0 — пока один мейнтейнер)"
-echo "    Файл: $ROOT/scripts/github-branch-protection-main.json"
-if gh api --method PUT "repos/${FULL}/branches/main/protection" \
+echo "==> Защита веток main и dev (PR, без approve; allow_deletions=false — ветки не удалять)"
+echo "    Файл: $ROOT/scripts/github-branch-protection-main.json (тот же payload для обеих)"
+if ! gh api --method PUT "repos/${FULL}/branches/main/protection" \
   --input "$ROOT/scripts/github-branch-protection-main.json"; then
-  echo "    OK: branch protection применён."
-else
-  echo "    Ошибка API (часто 422). Настройте Ruleset вручную: Settings → Rules → Rulesets"
-  echo "    См. docs/GITHUB_SETUP_GH.ru.md"
+  echo "    Ошибка: main (часто 422 — используйте Rulesets). См. docs/GITHUB_SETUP_GH.ru.md"
   exit 1
+fi
+echo "    OK: main"
+if gh api --method PUT "repos/${FULL}/branches/dev/protection" \
+  --input "$ROOT/scripts/github-branch-protection-main.json"; then
+  echo "    OK: dev"
+else
+  echo "    Пропуск dev: ветки нет или API 422 — создайте dev, затем:"
+  echo "    gh api --method PUT repos/${FULL}/branches/dev/protection --input scripts/github-branch-protection-main.json"
 fi
 
 echo ""


### PR DESCRIPTION
## Зачем
- `main` и `dev` — **не удаляемые** long-lived ветки.
- Причина пропажи `dev`: **Automatically delete head branches** + merge PR `dev`→`main`.

## Что сделано
- `github-repo-bootstrap.sh`: без `--delete-branch-on-merge`, `delete_branch_on_merge=false` через API; protection для `dev` (тот же JSON, что `main`, `allow_deletions: false`).
- Доки GITHUB_SETUP (EN/RU).

## Уже на GitHub (вне PR)
- `delete_branch_on_merge=false` для репозитория применено через `gh api`.

## После merge
1. Создать ветку `dev` от `main` и `git push -u origin dev`, если её ещё нет.
2. Выполнить: `gh api --method PUT repos/Gfermoto/BirdLense-Hub/branches/dev/protection --input scripts/github-branch-protection-main.json`
3. В Rulesets при необходимости дублировать запрет удаления для `dev`.

Made with [Cursor](https://cursor.com)