### PR TITLE
fix: prune без cron; скрипт карточек бэклога на Project

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -1,11 +1,9 @@
-# Удалить на origin все ветки кроме main и dev (заброшенные фичи, забытые ветки).
+# Опционально: снять с origin ветки кроме main и dev (ручной запуск мейнтейнером).
+# Обычная уборка — только автоматическое удаление head-ветки после merge PR (delete_branch_on_merge).
 name: Prune remote branches
 
 on:
   workflow_dispatch:
-  schedule:
-    # Понедельник 06:00 UTC — не даём веткам копиться; main и dev не трогаем.
-    - cron: "0 6 * * 1"
 
 permissions:
   contents: write
@@ -14,7 +12,7 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete all branches except main and dev
+      - name: Delete remote branches except main and dev (manual only)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Roadmap: секция **Backlog consilium (March 2026)** + 12 GitHub Issues [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) для доски Project.
-- CI: workflow `prune-branches.yml` — удаление на `origin` всех веток кроме **`main`** и **`dev`** (`workflow_dispatch` + **cron** понедельник 06:00 UTC).
+- CI: workflow `prune-branches.yml` — опционально, только **`workflow_dispatch`**: снятие с `origin` веток кроме **`main`** и **`dev`** (без cron; обычная уборка — после merge PR).
+- Скрипт `scripts/github-project-add-backlog-consilium.sh` — добавить issues **#46–#57** на доску Project (нужен scope `project` у `gh`).
 - `.github/github-social-preview.png` — Open Graph / Social preview для репозитория (1280×640).
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,4 +89,10 @@ New projects start **empty**. To add all **open issues and PRs** to the board:
 bash scripts/github-project-import-open-items.sh
 ```
 
+Roadmap backlog issues **#46–#57** (see [docs/ROADMAP.md](docs/ROADMAP.md)):
+
+```bash
+bash scripts/github-project-add-backlog-consilium.sh
+```
+
 On **WSL**, `gh project view … --web` often fails (`xdg-open: Permission denied`); open the printed **https://github.com/users/…/projects/N** link in your Windows browser instead.

--- a/CONTRIBUTING.ru.md
+++ b/CONTRIBUTING.ru.md
@@ -89,4 +89,10 @@ bash scripts/github-bootstrap-project.sh
 bash scripts/github-project-import-open-items.sh
 ```
 
+Бэклог из ROADMAP (issues **#46–#57**):
+
+```bash
+bash scripts/github-project-add-backlog-consilium.sh
+```
+
 В **WSL** команда `gh project view … --web` часто падает (`xdg-open: Permission denied`) — откройте напечатанную ссылку вида **https://github.com/users/…/projects/N** в браузере Windows.

--- a/docs/GITHUB_SETUP_GH.ru.md
+++ b/docs/GITHUB_SETUP_GH.ru.md
@@ -195,7 +195,7 @@ gh secret list -R "$FULL"
 
 - [ ] `main` и `dev` защищены: нет force-push, **нельзя удалить** ветку; фичи → PR в `dev`, релиз — PR `dev` → `main`.
 - [ ] **Automatically delete head branches** включено (`delete_branch_on_merge=true`): фича-ветки после merge не копятся; `main`/`dev` не удаляются (защита).
-- [ ] Workflow **Prune remote branches** (по cron или вручную) — подчистить забытые ветки, кроме `main` и `dev`.
+- [ ] (Опционально) Workflow **Prune remote branches** — только **вручную** (`workflow_dispatch`), если нужно снять забытые ветки с `origin`; обычно хватает удаления ветки **после merge** PR.
 - [ ] Pages: сайт открывается, последний workflow **Documentation site** зелёный на `main`.
 - [ ] Dependabot PR’ы не копятся месяцами.
 - [ ] **Deploy** workflow: либо runner поднят, либо workflow отключён / не required, чтобы не было вечных красных статусов.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,16 @@ Direction of travel and current stack. **Shipped items** are summarized here; de
 
 **Brainstorm roles:** product (operator value), security, platform/infra, ML & data, integrations (MQTT/HA/Frigate), UX, docs & OSS hygiene.
 
-**Outcome:** triaged items are **GitHub Issues** (not shipped until closed in a release): [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57). Add them to the repo **Project** board (Backlog / Todo column). If `gh project` fails locally, run `gh auth refresh -s read:project,project` and attach issues in the GitHub UI.
+**Outcome:** triaged items are **GitHub Issues** (not shipped until closed in a release): [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
+
+**Put them on the Project board** (needs `project` + `read:project` on `gh`):
+
+```bash
+gh auth refresh -h github.com -s read:project -s project   # or full `gh auth login` with those scopes
+bash scripts/github-project-add-backlog-consilium.sh
+```
+
+All open issues/PRs: `bash scripts/github-project-import-open-items.sh`. Or add cards manually in the GitHub UI.
 
 | # | Theme | Issue | Labels (summary) |
 |---|--------|-------|------------------|

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -35,7 +35,16 @@
 
 **Роли (мозговой штурм):** продукт/оператор, безопасность, платформа и CI, ML и данные, интеграции (MQTT, HA, Frigate), UX, документация и open-source гигиена.
 
-**Результат:** задачи заведены как **Issues** на GitHub: [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57). Их нужно добавить на **Project**-доску репозитория (колонка Backlog / Todo). Если команда `gh project` ругается на права — выполните `gh auth refresh -s read:project,project` или перенесите issues вручную в веб-интерфейсе GitHub.
+**Результат:** задачи заведены как **Issues** на GitHub: [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
+
+**Карточки на доске Project** (нужны scope `project` и `read:project` у `gh`):
+
+```bash
+gh auth refresh -h github.com -s read:project -s project   # или полный gh auth login с этими scope
+bash scripts/github-project-add-backlog-consilium.sh
+```
+
+Все открытые issues/PR: `bash scripts/github-project-import-open-items.sh`. Либо вручную в интерфейсе GitHub.
 
 | # | Тема | Issue | Приоритет / зона |
 |---|------|-------|------------------|

--- a/scripts/github-project-add-backlog-consilium.sh
+++ b/scripts/github-project-add-backlog-consilium.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Добавляет на GitHub Project карточки по issues бэклога из ROADMAP (консилиум): #46–#57.
+# Нужны те же права, что для github-project-import-open-items.sh:
+#   gh auth login … -s project -s read:project
+#
+# Использование:
+#   bash scripts/github-project-add-backlog-consilium.sh
+#
+set -euo pipefail
+
+OWNER="${GITHUB_PROJECT_OWNER:-Gfermoto}"
+REPO_FULL="${GITHUB_REPO:-Gfermoto/BirdLense-Hub}"
+PROJECT_TITLE="${GITHUB_PROJECT_TITLE:-BirdLense Hub — Roadmap}"
+# Issues из docs/ROADMAP.md § Backlog consilium
+ISSUE_START="${GITHUB_BACKLOG_ISSUE_START:-46}"
+ISSUE_END="${GITHUB_BACKLOG_ISSUE_END:-57}"
+
+command -v jq >/dev/null || { echo "Нужна утилита jq"; exit 1; }
+
+TMPERR=$(mktemp)
+trap 'rm -f "$TMPERR"' EXIT
+
+if ! gh project list --owner "$OWNER" --limit 1 >/dev/null 2>"$TMPERR"; then
+  echo "Нет доступа к Projects (нужны scope project / read:project):"
+  cat "$TMPERR"
+  echo ""
+  echo "Выполните: gh auth refresh -h github.com -s read:project -s project"
+  echo "или: gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project"
+  exit 1
+fi
+
+exists_json=$(gh project list --owner "$OWNER" --format json --limit 50)
+proj_num=$(echo "$exists_json" | jq -r --arg t "$PROJECT_TITLE" '.projects[] | select(.title == $t) | .number' | head -1)
+
+if [[ -z "$proj_num" || "$proj_num" == "null" ]]; then
+  echo "Проект «$PROJECT_TITLE» не найден. Сначала: bash scripts/github-bootstrap-project.sh"
+  exit 1
+fi
+
+echo "Проект #$proj_num «$PROJECT_TITLE» — добавляю issues ${ISSUE_START}..${ISSUE_END} из $REPO_FULL"
+
+added=0
+skipped=0
+failed=0
+
+for n in $(seq "$ISSUE_START" "$ISSUE_END"); do
+  url="https://github.com/${REPO_FULL}/issues/${n}"
+  if gh project item-add "$proj_num" --owner "$OWNER" --url "$url" 2>"$TMPERR"; then
+    echo "  + #$n"
+    added=$((added + 1))
+  else
+    err=$(tr '\n' ' ' <"$TMPERR")
+    if echo "$err" | grep -qiE 'already|exist|duplicate|in the project|not found'; then
+      echo "  = #$n (уже на доске или issue не найден)"
+      skipped=$((skipped + 1))
+    else
+      echo "  ! #$n — $err"
+      failed=$((failed + 1))
+    fi
+  fi
+done
+
+echo ""
+echo "Итого: добавлено $added, пропущено/уже есть $skipped, ошибок $failed"
+proj_url=$(gh project view "$proj_num" --owner "$OWNER" --format json 2>/dev/null | jq -r '.url // empty')
+[[ -z "$proj_url" || "$proj_url" == "null" ]] && proj_url="https://github.com/users/${OWNER}/projects/${proj_num}"
+echo "Доска: $proj_url"


### PR DESCRIPTION
## Prune
- Убран **cron** — ветки с `origin` не чистятся по расписанию.
- Удаление фича-веток — **только после merge** (`delete_branch_on_merge`). Workflow **Prune** — опционально вручную.

## Доска GitHub
- `scripts/github-project-add-backlog-consilium.sh` — добавляет **#46–#57** на проект «BirdLense Hub — Roadmap».
- ROADMAP / CONTRIBUTING / GITHUB_SETUP — явные команды + `gh auth refresh -h github.com -s read:project -s project`.

Made with [Cursor](https://cursor.com)