### PR TITLE
fix: GitHub Projects — PAT + .env.project, без OAuth refresh по кругу

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Скрипты GitHub Project: `scripts/github-project-pat-hint.sh`, загрузка `scripts/.env.project`, шаблон `scripts/env.project.example` — **classic PAT** вместо OAuth refresh (без круга device-login).
 - Roadmap: секция **Backlog consilium (March 2026)** + 12 GitHub Issues [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) для доски Project.
 - CI: workflow `prune-branches.yml` — опционально, только **`workflow_dispatch`**: снятие с `origin` веток кроме **`main`** и **`dev`** (без cron; обычная уборка — после merge PR).
 - Скрипт `scripts/github-project-add-backlog-consilium.sh` — добавить issues **#46–#57** на доску Project (нужен scope `project` у `gh`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,13 +75,11 @@ Look for issues labelled **`good first issue`** — small, scoped tasks for newc
 
 **Issues**, **Discussions**, and **Projects** are enabled on the repo. Labels `area:*`, `priority:*`, and `triage` support triage; milestones **v0.2.3** and **Backlog (no milestone)** are available.
 
-To create the Kanban project **BirdLense Hub — Roadmap** and link this repository, GitHub CLI needs **Projects** scopes. If `gh auth refresh -s project -s read:project` does nothing, do a full login (or use a **classic** PAT with the `project` scope as `GH_TOKEN` — see script header):
+To create the Kanban project **BirdLense Hub — Roadmap** and link this repository, `gh` must reach the **Projects** API. OAuth + `gh auth refresh -s project` often loops through device login — **use a classic PAT** instead:
 
-```bash
-gh auth logout -h github.com
-gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project
-bash scripts/github-bootstrap-project.sh
-```
+1. [New classic token](https://github.com/settings/tokens/new) → enable **repo** + **project**.
+2. `cp scripts/env.project.example scripts/.env.project` and set `export GH_TOKEN="ghp_…"` (file is gitignored via `.env.*`), **or** run `export GH_TOKEN=ghp_…` for one session.
+3. `bash scripts/github-bootstrap-project.sh`
 
 New projects start **empty**. To add all **open issues and PRs** to the board:
 

--- a/CONTRIBUTING.ru.md
+++ b/CONTRIBUTING.ru.md
@@ -75,13 +75,11 @@ make start
 
 В репозитории включены **Issues**, **Discussions** и **Projects**. Метки `area:*`, `priority:*`, `triage` и вехи **v0.2.3** / **Backlog (no milestone)** уже заведены.
 
-Создать проект **BirdLense Hub — Roadmap**, привязать репозиторий и поле «Поток» (канбан). Нужны права **Projects** у токена gh. Если `gh auth refresh` не помогает — полный вход или classic PAT с scope `project` (см. комментарии в `scripts/github-bootstrap-project.sh`):
+Создать проект **BirdLense Hub — Roadmap**, привязать репозиторий и поле «Поток» (канбан). Для API Projects у `gh` OAuth и `auth refresh -s project` часто крутят **device login** — проще **classic PAT**:
 
-```bash
-gh auth logout -h github.com
-gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project
-bash scripts/github-bootstrap-project.sh
-```
+1. [Новый classic token](https://github.com/settings/tokens/new) → **repo** + **project**.
+2. `cp scripts/env.project.example scripts/.env.project` и вписать `export GH_TOKEN="ghp_…"` (файл не коммитится, шаблон `.env.*`), либо разово `export GH_TOKEN=ghp_…`.
+3. `bash scripts/github-bootstrap-project.sh`
 
 Новый проект изначально **без карточек**. Подтянуть все **открытые issues и PR** на доску:
 

--- a/docs/GITHUB_SETUP_GH.md
+++ b/docs/GITHUB_SETUP_GH.md
@@ -17,3 +17,5 @@ Set default repo for `gh` (avoids wrong target on `pr merge`):
 ```bash
 gh repo set-default Gfermoto/BirdLense-Hub
 ```
+
+**Projects / Kanban scripts:** if `gh auth refresh -s project` loops forever, use a **classic PAT** (`repo` + `project`) as `GH_TOKEN` or in `scripts/.env.project` — see [GITHUB_SETUP_GH.ru.md](./GITHUB_SETUP_GH.ru.md) §7a and `scripts/env.project.example`.

--- a/docs/GITHUB_SETUP_GH.ru.md
+++ b/docs/GITHUB_SETUP_GH.ru.md
@@ -191,6 +191,14 @@ gh secret list -R "$FULL"
 
 ---
 
+## 7a. Projects / доска: если «авторизация по кругу»
+
+Для `gh project …` и скриптов `github-project-*.sh` **не полагайтесь на `gh auth refresh -s project`** — часто бесконечный browser/device flow.
+
+**Стабильный вариант:** [classic PAT](https://github.com/settings/tokens/new) с **repo** + **project** → `export GH_TOKEN=ghp_…` или файл `scripts/.env.project` (шаблон `scripts/env.project.example`, в git не попадает).
+
+---
+
 ## Чеклист после настройки
 
 - [ ] `main` и `dev` защищены: нет force-push, **нельзя удалить** ветку; фичи → PR в `dev`, релиз — PR `dev` → `main`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,10 +33,9 @@ Direction of travel and current stack. **Shipped items** are summarized here; de
 
 **Outcome:** triaged items are **GitHub Issues** (not shipped until closed in a release): [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
 
-**Put them on the Project board** (needs `project` + `read:project` on `gh`):
+**Put them on the Project board:** OAuth scopes often loop on device login — use a **classic PAT** (`repo` + `project`) in `GH_TOKEN` or `scripts/.env.project` (see `scripts/env.project.example`), then:
 
 ```bash
-gh auth refresh -h github.com -s read:project -s project   # or full `gh auth login` with those scopes
 bash scripts/github-project-add-backlog-consilium.sh
 ```
 

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -37,10 +37,9 @@
 
 **Результат:** задачи заведены как **Issues** на GitHub: [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
 
-**Карточки на доске Project** (нужны scope `project` и `read:project` у `gh`):
+**Карточки на доске Project:** через OAuth/`auth refresh` часто крутится device-login — надёжнее **classic PAT** (`repo` + `project`) в `GH_TOKEN` или `scripts/.env.project` (шаблон `scripts/env.project.example`), затем:
 
 ```bash
-gh auth refresh -h github.com -s read:project -s project   # или полный gh auth login с этими scope
 bash scripts/github-project-add-backlog-consilium.sh
 ```
 

--- a/scripts/env.project.example
+++ b/scripts/env.project.example
@@ -1,0 +1,6 @@
+# Скопируйте в scripts/.env.project (файл в .gitignore через шаблон .env.*)
+# Classic PAT: https://github.com/settings/tokens/new
+#   Включите: repo, project («Full control of user projects»).
+# Не коммитьте scripts/.env.project и не публикуйте токен.
+
+export GH_TOKEN=""

--- a/scripts/github-bootstrap-project.sh
+++ b/scripts/github-bootstrap-project.sh
@@ -2,23 +2,27 @@
 # Создаёт GitHub Project (v2) у владельца, линкует репозиторий BirdLense-Hub,
 # добавляет поле «Поток» (Backlog → … → Done).
 #
-# Аутентификация (любой рабочий вариант):
+# Аутентификация (рекомендуется без круга device-login):
 #
-#   A) OAuth через браузер с нужными scope (надёжнее, чем только refresh):
-#        gh auth logout -h github.com
-#        gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project
-#
-#   B) Классический PAT: https://github.com/settings/tokens/new
-#      Включите scope «project» (и «repo», «read:org» как минимум).
+#   A) Classic PAT — самый стабильный для gh project:* :
+#        https://github.com/settings/tokens/new → repo + project
 #        export GH_TOKEN=ghp_xxxxxxxx
 #        bash scripts/github-bootstrap-project.sh
+#      Или: cp scripts/env.project.example scripts/.env.project и вписать токен (файл в .gitignore).
 #
-#   Вариант «refresh» часто НЕ добавляет project, если токен fine-grained или кэш не обновился.
+#   B) OAuth: gh auth login -h github.com -w -s repo … project read:project
+#      (часто «refresh -s project» крутит браузер — для скриптов лучше PAT.)
 #
 # После создания проекта по умолчанию вызывается импорт открытых issues/PR
 # (github-project-import-open-items.sh). Отключить: GITHUB_PROJECT_IMPORT_OPEN=0
 #
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=github-project-pat-hint.sh
+source "$SCRIPT_DIR/github-project-pat-hint.sh"
+github_project_load_env "$ROOT"
 
 OWNER="${GITHUB_PROJECT_OWNER:-Gfermoto}"
 REPO_FULL="${GITHUB_REPO:-Gfermoto/BirdLense-Hub}"
@@ -26,18 +30,11 @@ PROJECT_TITLE="${GITHUB_PROJECT_TITLE:-BirdLense Hub — Roadmap}"
 
 die_help() {
   echo ""
-  echo "=== Что сделать ==="
-  echo "1) Посмотрите scopes:  gh auth status"
-  echo "   Нужны в списке: project и read:project (или один classic PAT с правом Projects)."
-  echo ""
-  echo "2) Надёжно: полный вход с scope:"
-  echo "     gh auth logout -h github.com"
-  echo "     gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project"
-  echo ""
-  echo "3) Или classic PAT в переменную (не коммитьте!):"
-  echo "     export GH_TOKEN=ghp_..."
-  echo "     bash scripts/github-bootstrap-project.sh"
-  echo ""
+  if [[ -n "${GH_TOKEN:-}" ]]; then
+    echo "Сейчас задан GH_TOKEN: нужен classic PAT с scope «project» (fine-grained только под repo часто не хватает)."
+    echo ""
+  fi
+  github_project_pat_hint
   exit 1
 }
 
@@ -48,11 +45,6 @@ if ! gh project list --owner "$OWNER" --limit 1 2>"$TMPERR"; then
   echo "Ошибка при gh project list:"
   sed 's/^/  /' "$TMPERR"
   echo ""
-  if [[ -n "${GH_TOKEN:-}" ]]; then
-    echo "Используется GH_TOKEN: убедитесь, что это классический PAT со scope «project» (fine-grained с ограничением только на репо Projects может не подойти)."
-  else
-    echo "Токен gh, скорее всего, без scope Projects. «gh auth refresh» иногда не меняет права (fine-grained / старый OAuth)."
-  fi
   die_help
 fi
 
@@ -77,8 +69,6 @@ gh project field-create "$proj_num" --owner "$OWNER" \
   --data-type "SINGLE_SELECT" \
   --single-select-options "Backlog,Ready,In progress,In review,Done" 2>/dev/null \
   || echo "(поле «Поток» уже есть или не удалось создать — проверьте в UI проекта)"
-
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 proj_url=$(gh project view "$proj_num" --owner "$OWNER" --format json --jq '.url' 2>/dev/null) || true
 if [[ -z "$proj_url" || "$proj_url" == "null" ]]; then

--- a/scripts/github-project-add-backlog-consilium.sh
+++ b/scripts/github-project-add-backlog-consilium.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # Добавляет на GitHub Project карточки по issues бэклога из ROADMAP (консилиум): #46–#57.
-# Нужны те же права, что для github-project-import-open-items.sh:
-#   gh auth login … -s project -s read:project
+#
+# Доступ к API Projects (надёжно): classic PAT в GH_TOKEN или в scripts/.env.project
+#   (см. scripts/env.project.example). OAuth «refresh -s project» часто крутит device-login.
 #
 # Использование:
 #   bash scripts/github-project-add-backlog-consilium.sh
 #
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=github-project-pat-hint.sh
+source "$SCRIPT_DIR/github-project-pat-hint.sh"
+github_project_load_env "$ROOT"
 
 OWNER="${GITHUB_PROJECT_OWNER:-Gfermoto}"
 REPO_FULL="${GITHUB_REPO:-Gfermoto/BirdLense-Hub}"
@@ -21,11 +28,10 @@ TMPERR=$(mktemp)
 trap 'rm -f "$TMPERR"' EXIT
 
 if ! gh project list --owner "$OWNER" --limit 1 >/dev/null 2>"$TMPERR"; then
-  echo "Нет доступа к Projects (нужны scope project / read:project):"
+  echo "Нет доступа к GitHub Projects:"
   cat "$TMPERR"
   echo ""
-  echo "Выполните: gh auth refresh -h github.com -s read:project -s project"
-  echo "или: gh auth login -h github.com -w -s repo -s read:org -s gist -s project -s read:project"
+  github_project_pat_hint
   exit 1
 fi
 

--- a/scripts/github-project-import-open-items.sh
+++ b/scripts/github-project-import-open-items.sh
@@ -2,9 +2,15 @@
 # Добавляет в GitHub Project все открытые issues и pull requests из репозитория.
 # Повторный запуск безопасен: уже добавленные элементы пропускаются (по тексту ошибки API).
 #
-# Те же права, что для github-bootstrap-project.sh (scope project / read:project).
+# Доступ: GH_TOKEN (classic PAT: repo + project) или scripts/.env.project — см. env.project.example
 #
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=github-project-pat-hint.sh
+source "$SCRIPT_DIR/github-project-pat-hint.sh"
+github_project_load_env "$ROOT"
 
 OWNER="${GITHUB_PROJECT_OWNER:-Gfermoto}"
 REPO_FULL="${GITHUB_REPO:-Gfermoto/BirdLense-Hub}"
@@ -16,8 +22,10 @@ TMPERR=$(mktemp)
 trap 'rm -f "$TMPERR"' EXIT
 
 if ! gh project list --owner "$OWNER" --limit 1 >/dev/null 2>"$TMPERR"; then
-  echo "Нет доступа к Projects:"
+  echo "Нет доступа к GitHub Projects:"
   cat "$TMPERR"
+  echo ""
+  github_project_pat_hint
   exit 1
 fi
 

--- a/scripts/github-project-pat-hint.sh
+++ b/scripts/github-project-pat-hint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Подключается из других скриптов (source). Не запускать напрямую.
+# shellcheck shell=bash
+
+# Загрузить scripts/.env.project (gitignore) — внутри: export GH_TOKEN="ghp_..."
+github_project_load_env() {
+  local root="$1"
+  local f="$root/scripts/.env.project"
+  if [[ -f "$f" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$f"
+    set +a
+    [[ -n "${GH_TOKEN:-}" ]] && echo "Загружен $f (GH_TOKEN для gh)."
+  fi
+}
+
+github_project_pat_hint() {
+  cat <<'EOF'
+=== Доступ к GitHub Projects: без «device login» по кругу ===
+
+OAuth и «gh auth refresh -s project» часто уходят в бесконечный browser/device flow.
+Для скриптов проекта надёжнее classic PAT:
+
+1) Создать токен: https://github.com/settings/tokens/new
+   Включить: ✓ repo, ✓ project (Full control of user projects).
+
+2) Вариант A — только на эту команду:
+     export GH_TOKEN=ghp_xxxxxxxx
+     bash scripts/…
+
+   Вариант B — файл (не коммитить, шаблон: scripts/env.project.example):
+     cp scripts/env.project.example scripts/.env.project
+     # отредактировать GH_TOKEN в scripts/.env.project
+
+3) Проверка:
+     GH_TOKEN=ghp_… gh project list --owner Gfermoto --limit 3
+
+Токен не передавать в чаты и не коммитить.
+EOF
+}


### PR DESCRIPTION
## Проблема
`gh auth refresh -s project` / device login по кругу.

## Решение
- Classic PAT (`repo` + `project`) в `GH_TOKEN` или `scripts/.env.project` (шаблон `env.project.example`, gitignore).
- Общий `github-project-pat-hint.sh`, автозагрузка в bootstrap + import + backlog скриптах.
- Доки: CONTRIBUTING, ROADMAP, GITHUB_SETUP §7a.

Made with [Cursor](https://cursor.com)