### PR TITLE
ci: docker-tests (processor + web pytest)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -50,3 +50,41 @@ jobs:
 
       - name: MkDocs build (strict)
         run: mkdocs build --strict
+
+  # Те же тесты, что локально: processor (unittest) + web (pytest) в образе birdlense.
+  # Требует места на диске раннера (база Ultralytics). Добавьте job **docker-tests**
+  # в required checks ruleset **Protect** вместе с ui-build и docs.
+  docker-tests:
+    name: docker-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Free disk space (large Docker image)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell || true
+          df -h
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare .env and data dirs
+        run: |
+          test -f .env || cp .env.example .env
+          mkdir -p data/db data/recordings
+
+      - name: Build birdlense image
+        run: docker compose build birdlense
+        env:
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+
+      - name: Processor unit tests
+        run: make test
+
+      - name: Web API tests (pytest)
+        run: make test-web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- CI: job **`docker-tests`** — сборка образа `birdlense` + `make test` + `make test-web` на каждый PR/push в `main` и `dev` (см. [TESTING](docs/TESTING.md)); в ruleset **Protect** добавить required check **`docker-tests`**.
 - Скрипты GitHub Project: `scripts/github-project-pat-hint.sh`, загрузка `scripts/.env.project`, шаблон `scripts/env.project.example` — **classic PAT** вместо OAuth refresh (без круга device-login).
 - Roadmap: секция **Backlog consilium (March 2026)** + 11 активных GitHub Issues [#46](https://github.com/Gfermoto/BirdLense-Hub/issues/46)–[#48](https://github.com/Gfermoto/BirdLense-Hub/issues/48), [#50](https://github.com/Gfermoto/BirdLense-Hub/issues/50)–[#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) для доски Project ([#49](https://github.com/Gfermoto/BirdLense-Hub/issues/49) ARM — вне скоупа).
 - CI: workflow `prune-branches.yml` — опционально, только **`workflow_dispatch`**: снятие с `origin` веток кроме **`main`** и **`dev`** (без cron; обычная уборка — после merge PR).

--- a/docs/GITHUB_SETUP_GH.md
+++ b/docs/GITHUB_SETUP_GH.md
@@ -8,7 +8,7 @@ Full Russian walkthrough: **[GITHUB_SETUP_GH.ru.md](./GITHUB_SETUP_GH.ru.md)** (
 ./scripts/github-repo-bootstrap.sh
 ```
 
-Branch protection: [`scripts/github-branch-protection-main.json`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/scripts/github-branch-protection-main.json) for **both** `main` and `dev` (`allow_deletions: false`). **Workflow:** feature PR → **`dev`**, then **`dev` → `main`**. Turn **on** **Automatically delete head branches** so merged feature branches are removed; protected `main`/`dev` are not deleted. Rulesets + **`ui-build`** / **`docs`** — see [GITHUB_SETUP_GH.ru.md](./GITHUB_SETUP_GH.ru.md) §4.
+Branch protection: [`scripts/github-branch-protection-main.json`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/scripts/github-branch-protection-main.json) for **both** `main` and `dev` (`allow_deletions: false`). **Workflow:** feature PR → **`dev`**, then **`dev` → `main`**. Turn **on** **Automatically delete head branches** so merged feature branches are removed; protected `main`/`dev` are not deleted. Rulesets + **`ui-build`** / **`docs`** / **`docker-tests`** — see [GITHUB_SETUP_GH.ru.md](./GITHUB_SETUP_GH.ru.md) §4.
 
 Wiki + CI reports: [WIKI_AUTOMATION.md](./WIKI_AUTOMATION.md).
 

--- a/docs/GITHUB_SETUP_GH.ru.md
+++ b/docs/GITHUB_SETUP_GH.ru.md
@@ -148,7 +148,9 @@ gh api "repos/$FULL" -X PATCH -f delete_branch_on_merge=true
 
 ### Обязательные status checks (ruleset **Protect**)
 
-На default branch в ruleset включены проверки из workflow **CI**: **`ui-build`** и **`docs`** (они бегают на каждый push/PR в `main` и `dev`). Approve по-прежнему **0** — для одного разработчика.
+На default branch в ruleset включены проверки из workflow **CI**: **`ui-build`**, **`docs`** и **`docker-tests`** (processor + web pytest в Docker; долгий job из‑за образа Ultralytics). Approve по-прежнему **0** — для одного разработчика.
+
+Если **`docker-tests`** ещё не в ruleset — добавьте в **Settings → Rules → Protect → Require status checks** (имя job как в Actions).
 
 **Не добавляйте** как required checks workflow **Documentation site** или **Deploy**, если они не гарантированно запускаются на каждый merge (фильтры путей, self-hosted).
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -12,6 +12,14 @@
 
 ## 1. Automated tests (development & CI)
 
+On **GitHub** (PR/push to `main` and `dev`), workflow **CI** runs:
+
+- **`ui-build`** — `npm ci` + production build of the SPA  
+- **`docs`** — MkDocs `--strict` + docs version check  
+- **`docker-tests`** — `docker compose build` + `make test` + `make test-web` (same as below)
+
+Add **`docker-tests`** as a **required** check in the **Protect** ruleset next to `ui-build` and `docs` (see [GITHUB_SETUP_GH](./GITHUB_SETUP_GH.md)).
+
 ### Processor unit tests
 
 ```bash

--- a/docs/TESTING.ru.md
+++ b/docs/TESTING.ru.md
@@ -12,6 +12,14 @@
 
 ## Тесты (разработка, CI)
 
+На **GitHub** (PR/push в `main` и `dev`) workflow **CI** запускает:
+
+- **`ui-build`** — `npm ci` + production-сборка SPA  
+- **`docs`** — MkDocs `--strict` + проверка версии в доках  
+- **`docker-tests`** — `docker compose build` + `make test` + `make test-web` (как ниже)
+
+Добавьте job **`docker-tests`** в **required checks** ruleset **Protect** рядом с `ui-build` и `docs` (см. [GITHUB_SETUP_GH.ru](./GITHUB_SETUP_GH.ru.md)).
+
 ### Unit-тесты (processor)
 
 ```bash


### PR DESCRIPTION
## Что сделано
- Новый job **`docker-tests`** в **CI**: `docker compose build birdlense` → `make test` → `make test-web` (как локально).
- Освобождение места на раннере перед сборкой (образ Ultralytics).
- Доки: **TESTING**, **GITHUB_SETUP_GH** — добавить **`docker-tests`** в required checks ruleset **Protect**.

## После merge
В **Settings → Rules → Protect** добавьте status check **`docker-tests`** (имя job в Actions), иначе merge не будет блокироваться этим шагом.

## Примечание
Первый прогон job может занять **15–25+ мин** (pull + build).

Made with [Cursor](https://cursor.com)