### PR TITLE
docs: Prometheus + Alertmanager examples (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Примеры алертинга Prometheus: `examples/prometheus/birdlense.rules.yml`, `examples/prometheus/alertmanager.birdlense.example.yml`; раздел **Alerting** в [CONFIGURATION](docs/CONFIGURATION.md) / RU — закрывает [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
 - `app/ui/package.json`: поле **`engines`** (Node **22.x**, минимум **22.13**; npm **>=10**) — согласовано с CI и UI Docker stage.
 - `.vscode/extensions.json` — рекомендуемые расширения (ESLint, Prettier, Docker).
 - CI: workflow **`E2E (Playwright)`** (`.github/workflows/e2e-scheduled.yml`) — раз в неделю + `workflow_dispatch`; **не** required в ruleset.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -308,6 +308,30 @@ scrape_configs:
 
 **Grafana** — Prometheus datasource, dashboard from metrics.
 
+### Alerting (Prometheus + Alertmanager)
+
+Ready-made examples live in the repo (tune thresholds and job labels to match your scrape config):
+
+| File | Purpose |
+|------|---------|
+| [`examples/prometheus/birdlense.rules.yml`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/examples/prometheus/birdlense.rules.yml) | Alerts: target down, disk/memory/CPU pressure, optional “no new detections in 24h” |
+| [`examples/prometheus/alertmanager.birdlense.example.yml`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/examples/prometheus/alertmanager.birdlense.example.yml) | Minimal Alertmanager `route` / `receivers` skeleton |
+
+**Prometheus** — add `rule_files` next to `scrape_configs`:
+
+```yaml
+rule_files:
+  - 'birdlense.rules.yml'   # path to the copied example
+```
+
+**Notes:**
+
+- Default rules assume scrape **`job_name: birdlense`** (see `up{job="birdlense"}`). If you rename the job, update every `job=` matcher in the rule file.
+- **`BirdlenseDetectionsUnchanged24h`** is optional and noisy when the feeder is off-season — increase `for`, mute in Alertmanager, or remove the rule group `birdlense-optional-activity`.
+- GPU alerts are not included: `birdlense_gpu_usage_percent` is only exported when the container sees a usable GPU sysfs path; “stall” is better diagnosed via **System → Processor logs** and `/api/ui/status`.
+
+Tracked as [issue #57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
+
 ---
 
 ## Secrets

--- a/docs/CONFIGURATION.ru.md
+++ b/docs/CONFIGURATION.ru.md
@@ -307,6 +307,30 @@ scrape_configs:
 
 **Grafana** — Prometheus datasource, дашборд по метрикам.
 
+### Алертинг (Prometheus + Alertmanager)
+
+Готовые примеры в репозитории (подстройте пороги и имя `job` под ваш `scrape_configs`):
+
+| Файл | Назначение |
+|------|------------|
+| [`examples/prometheus/birdlense.rules.yml`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/examples/prometheus/birdlense.rules.yml) | Алерты: таргет недоступен, диск/память/CPU, опционально «нет новых детекций за 24 ч» |
+| [`examples/prometheus/alertmanager.birdlense.example.yml`](https://github.com/Gfermoto/BirdLense-Hub/blob/main/examples/prometheus/alertmanager.birdlense.example.yml) | Каркас Alertmanager: `route` / `receivers` |
+
+**Prometheus** — добавьте `rule_files` рядом со `scrape_configs`:
+
+```yaml
+rule_files:
+  - 'birdlense.rules.yml'   # путь к скопированному примеру
+```
+
+**Замечания:**
+
+- Правила по умолчанию ожидают scrape с **`job_name: birdlense`** (см. `up{job="birdlense"}`). Если имя job другое — обновите матчеры в файле правил.
+- **`BirdlenseDetectionsUnchanged24h`** — опционально: срабатывает в межсезонье или при выключенной кормушке; увеличьте `for`, замьте в Alertmanager или удалите группу `birdlense-optional-activity`.
+- Отдельных правил по GPU нет: `birdlense_gpu_usage_percent` экспортируется только при доступной статистике GPU; «зависания» смотрите в **System → Processor logs** и `/api/ui/status`.
+
+Задача: [issue #57](https://github.com/Gfermoto/BirdLense-Hub/issues/57).
+
 ---
 
 ## Secrets

--- a/examples/prometheus/alertmanager.birdlense.example.yml
+++ b/examples/prometheus/alertmanager.birdlense.example.yml
@@ -1,0 +1,38 @@
+# Example Alertmanager configuration snippet for BirdLense alerts.
+# Merge with your global config; adjust receivers (email, Slack, Telegram webhook, etc.).
+#
+# Docs: https://prometheus.io/docs/alerting/latest/configuration/
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default
+  group_by: ["alertname", "job", "instance"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = critical
+      receiver: critical
+      continue: true
+
+receivers:
+  - name: default
+    # webhook_configs:
+    #   - url: 'https://hooks.slack.com/services/XXX/YYY/ZZZ'
+  - name: critical
+    # email_configs:
+    #   - to: 'ops@example.com'
+    #     from: 'alertmanager@example.com'
+    #     smarthost: 'smtp.example.com:587'
+    #     auth_username: 'alertmanager@example.com'
+    #     auth_password: 'secret'
+
+inhibit_rules:
+  - source_matchers:
+      - severity = critical
+    target_matchers:
+      - severity = warning
+    equal: ["instance", "job"]

--- a/examples/prometheus/birdlense.rules.yml
+++ b/examples/prometheus/birdlense.rules.yml
@@ -1,0 +1,77 @@
+# Example Prometheus alerting rules for BirdLense Hub.
+# Copy into your Prometheus config (rule_files) and tune thresholds.
+#
+# Prerequisites:
+#   - Scrape job name must match labels below (default: job="birdlense").
+#   - Metrics from GET /api/metrics — see docs/CONFIGURATION.md → Prometheus / Grafana.
+#
+# Metric notes:
+#   - birdlense_detections_total / birdlense_videos_total reflect DB totals at scrape time
+#     (typed as counter in exposition; suitable for increase() over long windows).
+#   - birdlense_gpu_usage_percent is omitted when no GPU stats are available — do not alert on absent() unless you know the host always exposes GPU.
+
+groups:
+  - name: birdlense-availability
+    interval: 30s
+    rules:
+      - alert: BirdlenseTargetDown
+        expr: up{job="birdlense"} == 0
+        for: 3m
+        labels:
+          severity: critical
+        annotations:
+          summary: "BirdLense scrape target is down"
+          description: "Prometheus cannot scrape job {{ $labels.job }} / {{ $labels.instance }} for 3m."
+
+  - name: birdlense-resources
+    interval: 30s
+    rules:
+      - alert: BirdlenseDiskAlmostFull
+        expr: birdlense_disk_used_percent > 90
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BirdLense host disk usage high"
+          description: "Disk used is {{ $value | printf \"%.1f\" }}% on {{ $labels.instance }}. Recordings and DB need free space."
+
+      - alert: BirdlenseDiskCritical
+        expr: birdlense_disk_used_percent > 97
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "BirdLense disk critically full"
+          description: "Disk used {{ $value | printf \"%.1f\" }}% — risk of failed writes and SQLite errors."
+
+      - alert: BirdlenseMemoryHigh
+        expr: birdlense_memory_used_percent > 92
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BirdLense host memory pressure"
+          description: "Memory used {{ $value | printf \"%.1f\" }}%. Processor/YOLO may OOM; consider retention or more RAM."
+
+      - alert: BirdlenseCpuSaturated
+        expr: birdlense_cpu_usage_percent > 95
+        for: 30m
+        labels:
+          severity: info
+        annotations:
+          summary: "BirdLense CPU very high"
+          description: "CPU {{ $value | printf \"%.1f\" }}% for 30m — may be normal during heavy encoding; tune or mute if expected."
+
+  - name: birdlense-optional-activity
+    interval: 1m
+    rules:
+      # OPTIONAL: fires if there were zero new detection rows (DB total unchanged) over 24h.
+      # Mute or raise `for` in winter / when feeder is offline for days.
+      - alert: BirdlenseDetectionsUnchanged24h
+        expr: increase(birdlense_detections_total[24h]) == 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "No growth in birdlense_detections_total for 24h"
+          description: "Check processor, motion source, Frigate/MQTT, and /api/ui/status. Disable this alert if pausing the feeder is normal."


### PR DESCRIPTION
## Что сделано
- `examples/prometheus/birdlense.rules.yml` — алерты: таргет down, диск/память/CPU, опционально «нет прироста детекций 24ч»
- `examples/prometheus/alertmanager.birdlense.example.yml` — каркас Alertmanager
- **CONFIGURATION** EN/RU — подраздел **Alerting** с примечаниями по job label и сезонности

Closes #57

Made with [Cursor](https://cursor.com)