### PR TITLE
feat(processor): MQTT reconnect backoff и доки по пропускам (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Отчётность:** без отдельных страниц `PROJECT_REPORTING*` — правила в [docs/ROADMAP.md](docs/ROADMAP.md) / [RU](docs/ROADMAP.ru.md) и [CONTRIBUTING](CONTRIBUTING.md) / [RU](CONTRIBUTING.ru.md); вести **Issues** и доску, не дублировать политикой в `docs/`.
 - **Доки окружения:** прод-UI **https://birdlense.eyera.info/**, SSH **185.218.111.196:2222** — [`.cursor/rules/deploy.mdc`](.cursor/rules/deploy.mdc), [MCP_SETUP](docs/MCP_SETUP.md) / [RU](docs/MCP_SETUP.ru.md), пример [`scripts/deploy.local.sh.example`](scripts/deploy.local.sh.example).
 - **#85 (video neighbors):** `GET /api/ui/videos/:id/neighbors` теперь поддерживает локальный день (`day_scope=local`, `tz_offset_minutes`) и опциональный переход на соседние сутки (`cross_day`); UI страницы видео использует локальный режим по умолчанию.
+- **#50 (processor MQTT resilience):** MQTT-клиент процессора использует встроенный reconnect/backoff paho (`reconnect_min_delay`/`reconnect_max_delay`), а в конфиг/доки добавлены параметры и пояснение про пропуски live-событий при обрывах.
 
 ### Added
 

--- a/app/app_config/default_config.yaml
+++ b/app/app_config/default_config.yaml
@@ -79,6 +79,8 @@ mqtt:
   frigate_topic: "frigate/events"
   birdnet_topic: "birdnet"  # BirdNET-Go/Pi публикует сюда
   publish_topic: "birdlense/detections"
+  reconnect_min_delay: 5  # сек; стартовый backoff при потере связи
+  reconnect_max_delay: 300  # сек; потолок backoff
   # Home Assistant MQTT Autodiscovery — публикация config и state для автообнаружения
   ha_discovery: true
 

--- a/app/processor/src/main.py
+++ b/app/processor/src/main.py
@@ -240,6 +240,8 @@ def main():
             client_id=mqtt_client_id,
             ha_discovery=app_config.get('mqtt.ha_discovery', True),
             base_url=app_config.get('notifications.base_url', ''),
+            reconnect_min_delay=app_config.get('mqtt.reconnect_min_delay', 5),
+            reconnect_max_delay=app_config.get('mqtt.reconnect_max_delay', 300),
         )
         mqtt_aggregator.start()
         _heartbeat_mqtt_ref[0] = mqtt_aggregator

--- a/app/processor/src/motion_detectors/frigate_mqtt.py
+++ b/app/processor/src/motion_detectors/frigate_mqtt.py
@@ -78,6 +78,8 @@ class FrigateMQTTMotionDetector:
         label_filter=None,
         username=None,
         password=None,
+        reconnect_min_delay: int = 5,
+        reconnect_max_delay: int = 300,
     ):
         self.broker = broker
         self.port = port
@@ -92,6 +94,8 @@ class FrigateMQTTMotionDetector:
         self._thread = None
         self._connected = False
         self._stopped = False
+        self.reconnect_min_delay = max(1, int(reconnect_min_delay))
+        self.reconnect_max_delay = max(self.reconnect_min_delay, int(reconnect_max_delay))
 
     def _on_connect(self, client, userdata, flags, reason_code, properties=None):
         if reason_code == 0:
@@ -130,13 +134,16 @@ class FrigateMQTTMotionDetector:
         self._event.set()
 
     def _run_client(self):
-        retry_delay = 5
-        max_retry_delay = 300
+        retry_delay = self.reconnect_min_delay
         while True:
             try:
                 self._client = mqtt.Client(
                     callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                     client_id="birdlense_frigate",
+                )
+                self._client.reconnect_delay_set(
+                    min_delay=self.reconnect_min_delay,
+                    max_delay=self.reconnect_max_delay,
                 )
                 if self.username:
                     self._client.username_pw_set(self.username, self.password)
@@ -147,8 +154,8 @@ class FrigateMQTTMotionDetector:
                 self._client.connect(self.broker, self.port, 60)
                 self._client.subscribe(self.topic)
                 self._client.publish("birdlense/status", "online", qos=1, retain=True)
-                retry_delay = 5
-                self._client.loop_forever()
+                retry_delay = self.reconnect_min_delay
+                self._client.loop_forever(retry_first_connection=True)
             except Exception as e:
                 logger.error("Frigate MQTT error: %s, reconnecting in %ds", e, retry_delay)
             finally:
@@ -163,7 +170,7 @@ class FrigateMQTTMotionDetector:
             if self._stopped:
                 break
             time.sleep(retry_delay)
-            retry_delay = min(retry_delay * 2, max_retry_delay)
+            retry_delay = min(retry_delay * 2, self.reconnect_max_delay)
 
     def start(self):
         if not self.broker:

--- a/app/processor/src/mqtt_aggregator.py
+++ b/app/processor/src/mqtt_aggregator.py
@@ -142,6 +142,8 @@ class MQTTEventAggregator:
         client_id: str | None = None,
         ha_discovery: bool = True,
         base_url: str = "",
+        reconnect_min_delay: int = 5,
+        reconnect_max_delay: int = 300,
     ):
         """on_frigate_motion: (camera_filter, label_filter, callback). frigate_label_exclude: labels to ignore (e.g. cat, dog).
         client_id: MQTT client ID; use different ID when running test (args.input) to avoid conflict with main processor.
@@ -168,6 +170,8 @@ class MQTTEventAggregator:
         self._frigate_label_exclude = set(frigate_label_exclude or [])
         self.ha_discovery = ha_discovery
         self.base_url = (base_url or "").strip().rstrip("/")
+        self.reconnect_min_delay = max(1, int(reconnect_min_delay))
+        self.reconnect_max_delay = max(self.reconnect_min_delay, int(reconnect_max_delay))
 
     def _on_connect(self, client, userdata, flags, reason_code, properties=None):
         if reason_code == 0:
@@ -309,13 +313,16 @@ class MQTTEventAggregator:
                 self._events.append(ev)
 
     def _run_client(self):
-        retry_delay = 5
-        max_retry_delay = 300
+        retry_delay = self.reconnect_min_delay
         while True:
             try:
                 self._client = mqtt.Client(
                     callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
                     client_id=self.client_id,
+                )
+                self._client.reconnect_delay_set(
+                    min_delay=self.reconnect_min_delay,
+                    max_delay=self.reconnect_max_delay,
                 )
                 if self.username:
                     self._client.username_pw_set(self.username, self.password)
@@ -328,8 +335,9 @@ class MQTTEventAggregator:
                 for t in self.birdnet_topics:
                     self._client.subscribe(t, qos=1)
                 self._client.publish("birdlense/status", "online", qos=1, retain=True)
-                retry_delay = 5
-                self._client.loop_forever()
+                retry_delay = self.reconnect_min_delay
+                # paho handles exponential reconnect backoff inside the network loop.
+                self._client.loop_forever(retry_first_connection=True)
             except Exception as e:
                 logger.error("MQTT aggregator error: %s, reconnecting in %ds", e, retry_delay)
             finally:
@@ -343,7 +351,7 @@ class MQTTEventAggregator:
             if self._stopped:
                 break
             time.sleep(retry_delay)
-            retry_delay = min(retry_delay * 2, max_retry_delay)
+            retry_delay = min(retry_delay * 2, self.reconnect_max_delay)
 
     def start(self):
         if not self.broker:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,11 +113,15 @@ One connection — Frigate and BirdNET topics. Triggers: Frigate, BirdNET (when 
 | `frigate_topic` | Frigate events topic |
 | `birdnet_topic` | BirdNET topic |
 | `publish_topic` | BirdLense detection publish topic |
+| `reconnect_min_delay` | Minimum MQTT reconnect/backoff delay (seconds) |
+| `reconnect_max_delay` | Maximum MQTT reconnect/backoff delay (seconds) |
 | `ha_discovery` | Home Assistant MQTT discovery — Last Species, Bird at Feeder, etc. Default true. |
 
 **Topics:** `frigate/events` (Frigate), `birdnet` (BirdNET), `birdlense/detections` (publish), `birdlense/sensor/last_species/state` (HA), `birdlense/binary_sensor/bird_detected/state` (HA). Feeder relay: `homeassistant/switch/bird_feeder/command`.
 
 **BirdNET:** `CommonName`, `Confidence`, `BeginTime` (merge), `ScientificName`, `BirdImage.URL`. **Frigate:** `after` — `camera`, `label`, `sub_label` (species from Bird Classification), `frame_time`. `sub_label` wins over `label`.
+
+**Missed-event note:** during outages, MQTT events can be missed and are usually not replayed later (Frigate events are typically a live stream, not backlog replay). Use Frigate recording/clip retention as the source of historical truth.
 
 ---
 

--- a/docs/CONFIGURATION.ru.md
+++ b/docs/CONFIGURATION.ru.md
@@ -113,11 +113,15 @@
 | `frigate_topic` | Топик событий Frigate |
 | `birdnet_topic` | Топик BirdNET |
 | `publish_topic` | Топик публикации детекций BirdLense Hub |
+| `reconnect_min_delay` | Минимальная задержка reconnect/backoff MQTT (сек) |
+| `reconnect_max_delay` | Максимальная задержка reconnect/backoff MQTT (сек) |
 | `ha_discovery` | Home Assistant MQTT Autodiscovery — Last Species, Bird at Feeder и др. По умолчанию true. |
 
 **Топики:** `frigate/events` (Frigate), `birdnet` (BirdNET), `birdlense/detections` (публикация), `birdlense/sensor/last_species/state` (HA), `birdlense/binary_sensor/bird_detected/state` (HA). Реле кормушки: `homeassistant/switch/bird_feeder/command`.
 
 **BirdNET:** `CommonName`, `Confidence`, `BeginTime` (для слияния), `ScientificName`, `BirdImage.URL`. **Frigate:** `after` — `camera`, `label`, `sub_label` (вид из Bird Classification), `frame_time`. `sub_label` — приоритет над `label`.
+
+**Важно про пропуски:** при потере соединения события MQTT могут быть пропущены и обычно не «догоняются» задним числом (стандартно Frigate публикует их как live stream, без replay). Для истории опирайтесь на retention Frigate записей/клипов.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -72,7 +72,7 @@ curl -s http://YOUR_GO2RTC_HOST:1984/api/streams
 | 1 | `motion.source` still `opencv` | `user_config.yaml` → `motion.source` must be `frigate` (or appropriate MQTT path) |
 | 2 | Frigate camera not in `video.cameras` | `id` must match Frigate camera name |
 | 3 | `frigate_label_filter` empty | Default `["bird","Bird"]`; empty list drops all events |
-| 4 | MQTT not ready in 5s at boot | Log: `Frigate MQTT not connected, falling back to OpenCV` |
+| 4 | MQTT unavailable for a long time (broker/network) | Logs `MQTT aggregator disconnected` / `MQTT aggregator connected`; reconnect uses backoff (`mqtt.reconnect_min_delay` → `mqtt.reconnect_max_delay`) |
 | 5 | Topic mismatch | Frigate `mqtt.topic_prefix` → events on `PREFIX/events` |
 | 6 | QoS 0 + bad network | Events can be lost on reconnect |
 

--- a/docs/TROUBLESHOOTING.ru.md
+++ b/docs/TROUBLESHOOTING.ru.md
@@ -63,7 +63,7 @@ docker logs birdlense --tail 200 2>&1
 | 1 | `motion.source: opencv` (дефолт) | `user_config.yaml` → `motion.source` должен быть `frigate` или `mqtt` |
 | 2 | Камера Frigate не в `video.cameras` | `id` в cameras должен совпадать с именем камеры во Frigate |
 | 3 | `frigate_label_filter` пустой | Дефолт `["bird","Bird"]`; пустой список отбрасывает все события |
-| 4 | MQTT не подключился за 5 с при старте | Логи: `Frigate MQTT not connected, falling back to OpenCV` |
+| 4 | MQTT долго недоступен (брокер/сеть) | Логи `MQTT aggregator disconnected` / `MQTT aggregator connected`; reconnect идёт с backoff (`mqtt.reconnect_min_delay` → `mqtt.reconnect_max_delay`) |
 | 5 | `frigate_topic` не совпадает с Frigate | Frigate `mqtt.topic_prefix` → топик `PREFIX/events` |
 | 6 | MQTT QoS 0 — потеря при reconnect | Нестабильная сеть |
 


### PR DESCRIPTION
## Что сделано
- В `MQTTEventAggregator` добавлен управляемый reconnect/backoff через paho (`reconnect_delay_set`, `retry_first_connection`).
- В конфиг добавлены параметры `mqtt.reconnect_min_delay` и `mqtt.reconnect_max_delay`.
- Обновлены RU/EN docs (`CONFIGURATION`, `TROUBLESHOOTING`) с пояснением про пропуски live MQTT-событий и опору на retention Frigate.
- Обновлён `CHANGELOG.md`.

## Проверка
- `python3 -m py_compile app/processor/src/mqtt_aggregator.py app/processor/src/motion_detectors/frigate_mqtt.py app/processor/src/main.py`
- Полный `pytest` для `app/processor/tests` локально не стартует в текущем окружении из-за отсутствия `cv2` (ошибка импорта на collection).

Closes #50

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Заметки о выпуске

* **New Features**
  * Добавлены настраиваемые параметры MQTT `reconnect_min_delay` и `reconnect_max_delay` для управления задержками переподключения при разрывах соединения.

* **Documentation**
  * Обновлена документация с описанием новых параметров конфигурации.
  * Уточнено, что события могут быть потеряны во время отключений MQTT и обновлены руководства по устранению неполадок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->