### PR TITLE
chore(ci): отчёт и артефакт аудита Settings UI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,7 +49,23 @@ jobs:
         run: python3 scripts/check-docs-version.py
 
       - name: Check Settings UI coverage
-        run: python3 scripts/check-settings-ui-coverage.py
+        run: |
+          python3 scripts/check-settings-ui-coverage.py \
+            --report-path .artifacts/settings-ui-coverage.json \
+            --summary-path .artifacts/settings-ui-coverage.md
+
+      - name: Publish Settings UI coverage summary
+        if: always()
+        run: cat .artifacts/settings-ui-coverage.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Settings UI coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: settings-ui-coverage
+          path: |
+            .artifacts/settings-ui-coverage.json
+            .artifacts/settings-ui-coverage.md
 
       - name: MkDocs build (strict)
         run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **#85 (video neighbors):** `GET /api/ui/videos/:id/neighbors` теперь поддерживает локальный день (`day_scope=local`, `tz_offset_minutes`) и опциональный переход на соседние сутки (`cross_day`); UI страницы видео использует локальный режим по умолчанию.
 - **#50 (processor MQTT resilience):** MQTT-клиент процессора использует встроенный reconnect/backoff paho (`reconnect_min_delay`/`reconnect_max_delay`), а в конфиг/доки добавлены параметры и пояснение про пропуски live-событий при обрывах.
 - **Settings UI (MQTT):** в форму добавлены `publish_topic`, `reconnect_min_delay`, `reconnect_max_delay` для полной настройки MQTT без ручного редактирования YAML.
-- **CI/процесс:** добавлен `scripts/check-settings-ui-coverage.py` и проверка в `CI` — новые ключи из `default_config.yaml` теперь обязаны быть либо в Settings UI, либо явно добавлены в allowlist non-UI.
+- **CI/процесс:** добавлен `scripts/check-settings-ui-coverage.py` и проверка в `CI` — новые ключи из `default_config.yaml` теперь обязаны быть либо в Settings UI, либо явно добавлены в allowlist non-UI; в Actions публикуется сводка и артефакт аудита покрытия.
 
 ### Added
 

--- a/scripts/check-settings-ui-coverage.py
+++ b/scripts/check-settings-ui-coverage.py
@@ -9,8 +9,9 @@ Policy:
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
-import sys
 from pathlib import Path
 
 import yaml
@@ -21,41 +22,41 @@ SETTINGS_FORM_PATH = ROOT / "app" / "ui" / "src" / "pages" / "Settings" / "Setti
 
 
 # Intentionally hidden from Settings UI.
-# Keep this list short and explicit; add reason in the comment above key block.
-ALLOWED_NON_UI_KEYS = {
-    # Processor internals: model paths/strategy are deployment-level and can break runtime if edited casually.
-    "processor.detection_strategy",
-    "processor.models.single_stage",
-    "processor.models.binary",
-    "processor.models.classifier",
-    "processor.regional_species",
-    "processor.included_bird_families",
-    "processor.save_images",
-    # Motion fine-tuning kept as config-level for now.
-    "motion.frigate_camera_filter",
-    "motion.frigate_label_filter",
-    # Merge internals not yet presented in UI as separate controls.
-    "detection.merge_window_seconds",
-    "detection.dedup_window_seconds",
-    "detection.one_per_species",
-    "detection.source_priority",
-    "detection.species_mapping",
-    "detection.min_confidence_to_store",
+# Keep this list short and explicit; every key must have a reason.
+ALLOWED_NON_UI_KEYS: dict[str, str] = {
+    # Processor internals.
+    "processor.detection_strategy": "Deployment-level model strategy; unsafe for casual UI edits.",
+    "processor.models.single_stage": "Model path is environment/deployment-specific.",
+    "processor.models.binary": "Model path is environment/deployment-specific.",
+    "processor.models.classifier": "Model path is environment/deployment-specific.",
+    "processor.regional_species": "Advanced ML tuning; currently config-level only.",
+    "processor.included_bird_families": "Advanced ML tuning; currently config-level only.",
+    "processor.save_images": "Storage/performance-sensitive low-level switch.",
+    # Motion fine tuning.
+    "motion.frigate_camera_filter": "Advanced routing; kept config-level for now.",
+    "motion.frigate_label_filter": "Advanced routing; kept config-level for now.",
+    # Merge internals.
+    "detection.merge_window_seconds": "Advanced merge tuning; kept config-level for now.",
+    "detection.dedup_window_seconds": "Advanced merge tuning; kept config-level for now.",
+    "detection.one_per_species": "Advanced merge tuning; kept config-level for now.",
+    "detection.source_priority": "Advanced merge tuning; kept config-level for now.",
+    "detection.species_mapping": "Bulk mapping maintained as config dictionary.",
+    "detection.min_confidence_to_store": "Advanced filtering; currently config-level only.",
     # Ops/security-sensitive/infra-generated values.
-    "notifications.telegram_api_base",
-    "notifications.telegram_timeout",
-    "notifications.telegram_retries",
-    "notifications.compress_photo_over_kb",
-    "notifications.telegram_max_side_px",
-    "web_push.enabled",
-    "web_push.vapid_public_key",
-    "web_push.vapid_private_key",
-    # Runtime control still config-level.
-    "video.source",
-    "video.pre_record_seconds",
-    "video.auto_reconnect",
-    "retention.days",
-    "ebird.protocol",
+    "notifications.telegram_api_base": "Network/proxy endpoint; ops-level setting.",
+    "notifications.telegram_timeout": "Network resilience tuning; ops-level setting.",
+    "notifications.telegram_retries": "Network resilience tuning; ops-level setting.",
+    "notifications.compress_photo_over_kb": "Low-level delivery optimization; config-level.",
+    "notifications.telegram_max_side_px": "Low-level delivery optimization; config-level.",
+    "web_push.enabled": "Derived by backend from subscriptions.",
+    "web_push.vapid_public_key": "Generated/managed by backend.",
+    "web_push.vapid_private_key": "Secret generated/managed by backend.",
+    # Runtime controls still config-level.
+    "video.source": "Runtime mode selection; hidden from basic UI flow.",
+    "video.pre_record_seconds": "Advanced recording behavior tuning.",
+    "video.auto_reconnect": "Advanced stream behavior tuning.",
+    "retention.days": "Retention policy managed outside current settings form.",
+    "ebird.protocol": "Protocol is currently fixed in product flow.",
 }
 
 TERMINAL_MAP_KEYS = {
@@ -85,11 +86,97 @@ def _load_form_fields() -> set[str]:
     return set(re.findall(r'form\.Field name="([^"]+)"', text))
 
 
+def _build_report(config_keys: set[str], form_fields: set[str]) -> dict:
+    rows = []
+    for key in sorted(config_keys):
+        if key in form_fields:
+            status = "ui"
+            reason = ""
+        elif key in ALLOWED_NON_UI_KEYS:
+            status = "allowlisted_non_ui"
+            reason = ALLOWED_NON_UI_KEYS[key]
+        else:
+            status = "missing"
+            reason = "No UI field and not allowlisted."
+        rows.append({"key": key, "status": status, "reason": reason})
+    missing = [r["key"] for r in rows if r["status"] == "missing"]
+    return {
+        "summary": {
+            "config_keys": len(config_keys),
+            "ui_fields": len(form_fields),
+            "allowlisted_non_ui": len(ALLOWED_NON_UI_KEYS),
+            "missing": len(missing),
+        },
+        "missing_keys": missing,
+        "rows": rows,
+    }
+
+
+def _to_markdown(report: dict) -> str:
+    s = report["summary"]
+    lines = [
+        "## Settings UI Coverage Audit",
+        "",
+        f"- Config keys: **{s['config_keys']}**",
+        f"- UI fields: **{s['ui_fields']}**",
+        f"- Allowlisted non-UI keys: **{s['allowlisted_non_ui']}**",
+        f"- Missing keys: **{s['missing']}**",
+        "",
+        "| Key | Status | Reason |",
+        "|---|---|---|",
+    ]
+    for row in report["rows"]:
+        status = {
+            "ui": "UI",
+            "allowlisted_non_ui": "Allowlisted",
+            "missing": "Missing",
+        }[row["status"]]
+        reason = row["reason"] or "-"
+        lines.append(f"| `{row['key']}` | {status} | {reason} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--report-path",
+        default="",
+        help="Optional path to write JSON report.",
+    )
+    parser.add_argument(
+        "--summary-path",
+        default="",
+        help="Optional path to write Markdown summary table.",
+    )
+    parser.add_argument(
+        "--no-strict",
+        action="store_true",
+        help="Do not fail when missing keys exist.",
+    )
+    return parser.parse_args()
+
+
 def main() -> int:
+    args = _parse_args()
     cfg = yaml.safe_load(DEFAULT_CONFIG_PATH.read_text(encoding="utf-8"))
     config_keys = {k for k in _collect_terminal_keys(cfg) if k}
     form_fields = _load_form_fields()
-    missing = sorted(config_keys - form_fields - ALLOWED_NON_UI_KEYS)
+    report = _build_report(config_keys, form_fields)
+    missing = report["missing_keys"]
+    md = _to_markdown(report)
+
+    if args.report_path:
+        report_path = Path(args.report_path)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(
+            json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    if args.summary_path:
+        summary_path = Path(args.summary_path)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(md, encoding="utf-8")
 
     if missing:
         print("Settings UI coverage check FAILED.")
@@ -97,12 +184,14 @@ def main() -> int:
         for key in missing:
             print(f"  - {key}")
         print("\nEither add form fields in SettingsForm.tsx or add explicit allowlist entries.")
-        return 1
+        if not args.no_strict:
+            return 1
 
     print(
         "Settings UI coverage OK: "
         f"{len(config_keys)} config keys, {len(form_fields)} UI fields, "
-        f"{len(ALLOWED_NON_UI_KEYS)} allowlisted non-UI keys."
+        f"{len(ALLOWED_NON_UI_KEYS)} allowlisted non-UI keys, "
+        f"{len(missing)} missing."
     )
     return 0
 


### PR DESCRIPTION
## Что улучшено
- `scripts/check-settings-ui-coverage.py` теперь:
  - поддерживает `--report-path` (JSON) и `--summary-path` (Markdown);
  - формирует таблицу покрытия `config key -> status -> reason`;
  - хранит причины allowlist как явный словарь.
- В `.github/workflows/ci-pr.yml`:
  - добавлена генерация отчёта аудита;
  - summary добавляется в `$GITHUB_STEP_SUMMARY`;
  - отчёт загружается как artifact `settings-ui-coverage`.

## Зачем
- Требуется не только строгий fail/pass, но и прозрачный аудит по лучшим практикам: видно, какие ключи покрыты UI, какие сознательно скрыты и почему.

## Проверка локально
- `python3 scripts/check-settings-ui-coverage.py`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Расширена система аудита покрытия Settings UI: сводка проверки теперь публикуется в GitHub Actions с дополнительной классификацией конфигурационных ключей.
* Добавлены доступные артефакты с детальным JSON-отчётом и читаемой Markdown-сводкой результатов аудита.
* Добавлена поддержка флага `--no-strict` для более гибкого управления параметрами проверки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->