### PR TITLE
fix(overview): mean duration = mean recording length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CI/процесс:** `settings-ui-coverage` расширен метаданными зрелости для non-UI ключей (`ops-only`, `advanced`, `backend-managed`, `planned-ui`) с `reason` и `next_step`; это даёт прозрачный план эволюции настроек, а не только pass/fail.
 - **#51 (операторский UX):** в System добавлены безопасные `SQLite backup/restore` (скачивание бэкапа и восстановление из файла с авто-`pre_restore` копией), плюс документация в INSTALL/TROUBLESHOOTING.
 - **#52 (UI i18n):** добавлена пилотная третья локаль `de` (German) в `react-i18next`, улучшен выбор стартового языка (saved/browser/fallback), переключатель языка теперь полностью через i18n-ключи.
+- **Overview stats:** карточка `Средняя длительность` теперь считает среднюю длительность **одной записи** (`Video`), а не среднюю длительность визита (`SpeciesVisit`), чтобы метрика соответствовала названию.
 
 ### Added
 

--- a/app/ui/locales/en.json
+++ b/app/ui/locales/en.json
@@ -43,7 +43,7 @@
     "uniqueSpecies": "Unique Species",
     "totalVisits": "Total Visits",
     "visitsLastHour": "Visits (Last Hour)",
-    "meanDuration": "Mean Visit Duration",
+    "meanDuration": "Mean Recording Duration",
     "busiestHour": "Busiest Hour",
     "recordingTime": "Recording Time",
     "recordingTimeHint": "Sum of all video file durations for the day",

--- a/app/ui/locales/ru.json
+++ b/app/ui/locales/ru.json
@@ -43,7 +43,7 @@
     "uniqueSpecies": "Уникальных видов",
     "totalVisits": "Всего визитов",
     "visitsLastHour": "Визитов (последний час)",
-    "meanDuration": "Средняя длительность",
+    "meanDuration": "Средняя длительность записи",
     "busiestHour": "Пиковый час",
     "recordingTime": "Время записи",
     "recordingTimeHint": "Сумма длительностей всех видеофайлов за день",

--- a/app/web/services/overview_service.py
+++ b/app/web/services/overview_service.py
@@ -54,7 +54,7 @@ def get_overview_data(session, start_of_day: datetime, end_of_day: datetime) -> 
         func.sum(SpeciesVisit.max_simultaneous).desc()
     ).first()
 
-    # Stats
+    # Stats based on visits
     stats_q = session.query(
         func.count(distinct(SpeciesVisit.species_id)).label('uniqueSpecies'),
         func.sum(SpeciesVisit.max_simultaneous).label('totalDetections'),
@@ -65,10 +65,6 @@ def get_overview_data(session, start_of_day: datetime, end_of_day: datetime) -> 
                 else_=0
             )
         ).label('lastHourDetections'),
-        func.avg(
-            func.strftime('%s', SpeciesVisit.end_time) -
-            func.strftime('%s', SpeciesVisit.start_time)
-        ).label('avgVisitDuration'),
     ).join(Species, SpeciesVisit.species_id == Species.id).filter(
         SpeciesVisit.start_time >= start_of_day,
         SpeciesVisit.start_time <= end_of_day,
@@ -82,6 +78,12 @@ def get_overview_data(session, start_of_day: datetime, end_of_day: datetime) -> 
     )
     recording_sec = session.query(
         func.sum(video_dur_expr).label('total'),
+    ).filter(
+        Video.start_time >= start_of_day,
+        Video.start_time <= end_of_day,
+    ).scalar() or 0
+    avg_recording_sec = session.query(
+        func.avg(video_dur_expr).label('avg'),
     ).filter(
         Video.start_time >= start_of_day,
         Video.start_time <= end_of_day,
@@ -119,7 +121,8 @@ def get_overview_data(session, start_of_day: datetime, end_of_day: datetime) -> 
         'totalDetections': stats_q.totalDetections or 0,
         'lastHourDetections': stats_q.lastHourDetections or 0,
         'busiestHour': int(busiest.hour) if busiest else 0,
-        'avgVisitDuration': round(stats_q.avgVisitDuration or 0),
+        # UI card "Mean duration": average single recording duration (Video), not visit span.
+        'avgVisitDuration': round(avg_recording_sec),
         'videoDuration': round(recording_sec),  # время записей: сумма длительностей видеофайлов
         'audioDuration': round(dur_q.audio_duration or 0),
         'detectionByProvider': {(p or 'legacy'): int(c) for p, c in prov_q},


### PR DESCRIPTION
## Summary
- Changed Overview metric `avgVisitDuration` source to average `Video` duration for selected day.
- Kept `videoDuration` as total sum of all recordings for selected day (unchanged behavior).
- Updated UI labels:
  - RU: `Средняя длительность записи`
  - EN: `Mean Recording Duration`
- Updated changelog entry.

## Why
Users expect this card to represent average single recording length; visit-based duration can be much larger and misleading.

## Validation
- `cd app/ui && npm run build`
- Python syntax check for `overview_service.py`


Made with [Cursor](https://cursor.com)