### PR TITLE
chore(project): auto-sync board status, assignee and subtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Project hygiene:** скрипт `scripts/github-project-sync.sh` для автосинхронизации доски (Status/Поток по состоянию issue, auto-assignee для open задач без исполнителя, отчёт по open задачам без checklist-подзадач).
 - **#53 (CI):** workflow `.github/workflows/docker-image-smoke.yml` — ежедневный smoke-тест опубликованного `ghcr.io/<owner>/birdlense-hub:latest` (pull/run + проверка `/api/ui/health`).
 - **#48:** скрипт `scripts/datasets/export_birdlense_to_yolo.py` — экспорт локальных кропов BirdLense (`app/data/dataset/train`) в YOLO classification layout `train/val` с детерминированным split и `dataset_info.json`.
 - **#47 (maintainer hygiene):** скрипт `scripts/security/scan_git_history_secrets.sh` для прохода по полной git-истории через Gitleaks (Docker) + документированный процесс в [SECURITY](docs/SECURITY.md) / [RU](docs/SECURITY.ru.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 ```
 
 All open issues/PRs: `bash scripts/github-project-import-open-items.sh`. Or add cards manually in the GitHub UI.
+Status/assignee/checklist sync: `bash scripts/github-project-sync.sh --assign Gfermoto`.
 
 | # | Theme | Issue | Labels (summary) |
 |---|--------|-------|------------------|
@@ -72,7 +73,7 @@ All open issues/PRs: `bash scripts/github-project-import-open-items.sh`. Or add 
 
 **After consilium:** new tracked work → create/update the Issue, add the card to the Project (`github-project-add-backlog-consilium.sh` or manually), then **update this ROADMAP** table in the same PR or follow-up.
 
-**Reporting (all shipped work, not only consilium):** every shipped item has a **GitHub Issue** (open one if missing) and, when tracked, a card on **BirdLense Hub — Roadmap**. When done: comment (outcome + PR links), **close** the issue, set board **Status → Done** (with a PAT: `bash scripts/github-project-mark-done.sh <n>`). Checklist: root **[CONTRIBUTING.md](https://github.com/Gfermoto/BirdLense-Hub/blob/main/CONTRIBUTING.md)** § *Issues & Project board*.
+**Reporting (all shipped work, not only consilium):** every shipped item has a **GitHub Issue** (open one if missing) and, when tracked, a card on **BirdLense Hub — Roadmap**. When done: comment (outcome + PR links), **close** the issue, set board **Status → Done** (with a PAT: `bash scripts/github-project-mark-done.sh <n>`). For routine hygiene, run `bash scripts/github-project-sync.sh --assign Gfermoto` (aligns board status/flow with issue state, assigns open issues without assignee, reports open issues missing subtask checklists). Checklist: root **[CONTRIBUTING.md](https://github.com/Gfermoto/BirdLense-Hub/blob/main/CONTRIBUTING.md)** § *Issues & Project board*.
 
 ---
 

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -45,6 +45,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 ```
 
 Все открытые issues/PR: `bash scripts/github-project-import-open-items.sh`. Либо вручную в интерфейсе GitHub.
+Синхронизация статусов/assignee/чеклистов: `bash scripts/github-project-sync.sh --assign Gfermoto`.
 
 | # | Тема | Issue | Приоритет / зона |
 |---|------|-------|------------------|
@@ -74,7 +75,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 
 **После консилиума:** новая отслеживаемая работа → Issue, карточка на доске (`github-project-add-backlog-consilium.sh` или вручную), затем **обновить эту таблицу** в ROADMAP в том же или следующем PR.
 
-**Отчётность (вся работа, не только консилиум):** каждая сданная задача — **Issue** (нет карточки — завести) и при необходимости карточка на доске **BirdLense Hub — Roadmap**. По готовности: комментарий (итог + ссылки на PR), **закрыть** Issue, на доске **Status → Done** (при PAT: `bash scripts/github-project-mark-done.sh <номер>`). Подробности и чеклист — корневой **[CONTRIBUTING.ru.md](https://github.com/Gfermoto/BirdLense-Hub/blob/main/CONTRIBUTING.ru.md)** § *Issues и доска Project*.
+**Отчётность (вся работа, не только консилиум):** каждая сданная задача — **Issue** (нет карточки — завести) и при необходимости карточка на доске **BirdLense Hub — Roadmap**. По готовности: комментарий (итог + ссылки на PR), **закрыть** Issue, на доске **Status → Done** (при PAT: `bash scripts/github-project-mark-done.sh <номер>`). Для регулярной уборки рассинхрона использовать `bash scripts/github-project-sync.sh --assign Gfermoto` (выравнивает статус/поток по issue-state, назначает исполнителя на open без assignee, репортит задачи без подзадач). Подробности и чеклист — корневой **[CONTRIBUTING.ru.md](https://github.com/Gfermoto/BirdLense-Hub/blob/main/CONTRIBUTING.ru.md)** § *Issues и доска Project*.
 
 ---
 

--- a/scripts/github-project-sync.sh
+++ b/scripts/github-project-sync.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Синхронизирует GitHub Project с реальным состоянием issues:
+# - closed issue -> Status=Done (+ Поток=Done, если поле есть)
+# - open issue   -> Status=Todo  (+ Поток=Todo/Backlog, если есть)
+# - опционально назначает assignee для открытых issue без исполнителя
+# - печатает отчёт по open issue без checklist-подзадач
+#
+# Пример:
+#   bash scripts/github-project-sync.sh --assign Gfermoto
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# shellcheck source=github-project-pat-hint.sh
+source "$SCRIPT_DIR/github-project-pat-hint.sh"
+github_project_load_env "$ROOT"
+
+OWNER="${GITHUB_PROJECT_OWNER:-Gfermoto}"
+REPO_FULL="${GITHUB_REPO:-Gfermoto/BirdLense-Hub}"
+PROJECT_TITLE="${GITHUB_PROJECT_TITLE:-BirdLense Hub — Roadmap}"
+ASSIGNEE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --assign)
+      ASSIGNEE="${2:-}"
+      if [[ -z "$ASSIGNEE" ]]; then
+        echo "Пустой --assign. Пример: --assign Gfermoto"
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Неизвестный аргумент: $1"
+      echo "Использование: $0 [--assign <github-login>]"
+      exit 1
+      ;;
+  esac
+done
+
+command -v jq >/dev/null || { echo "Нужна утилита jq"; exit 1; }
+
+tmp_err=$(mktemp)
+trap 'rm -f "$tmp_err"' EXIT
+
+if ! gh project list --owner "$OWNER" --limit 1 >/dev/null 2>"$tmp_err"; then
+  echo "Нет доступа к GitHub Projects:"
+  cat "$tmp_err"
+  echo ""
+  github_project_pat_hint
+  exit 1
+fi
+
+proj_num=$(
+  gh project list --owner "$OWNER" --format json --limit 50 \
+    | jq -r --arg t "$PROJECT_TITLE" '.projects[] | select(.title == $t) | .number' \
+    | head -1
+)
+if [[ -z "$proj_num" || "$proj_num" == "null" ]]; then
+  echo "Проект «$PROJECT_TITLE» не найден."
+  exit 1
+fi
+
+proj_id=$(gh project view "$proj_num" --owner "$OWNER" --format json | jq -r '.id')
+fields_json=$(gh project field-list "$proj_num" --owner "$OWNER" --format json)
+items_json=$(gh project item-list "$proj_num" --owner "$OWNER" --format json --limit 500)
+
+status_field_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField") | .id' | head -1)
+status_done_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Done") | .id' | head -1)
+status_todo_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Todo") | .id' | head -1)
+if [[ -z "$status_todo_id" || "$status_todo_id" == "null" ]]; then
+  status_todo_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Backlog") | .id' | head -1)
+fi
+
+flow_field_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Поток" and .type == "ProjectV2SingleSelectField") | .id' | head -1)
+flow_done_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Поток" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Done") | .id' | head -1)
+flow_todo_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Поток" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Todo") | .id' | head -1)
+if [[ -z "$flow_todo_id" || "$flow_todo_id" == "null" ]]; then
+  flow_todo_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Поток" and .type == "ProjectV2SingleSelectField") | .options[]? | select(.name == "Backlog") | .id' | head -1)
+fi
+
+if [[ -z "$status_field_id" || "$status_field_id" == "null" || -z "$status_done_id" || "$status_done_id" == "null" ]]; then
+  echo "Не найдено поле Status с опцией Done."
+  exit 1
+fi
+if [[ -z "$status_todo_id" || "$status_todo_id" == "null" ]]; then
+  echo "Не найдено поле Status с опцией Todo/Backlog."
+  exit 1
+fi
+
+declare -A OPEN_ISSUES=()
+declare -A CLOSED_ISSUES=()
+while IFS= read -r n; do
+  [[ -n "$n" ]] && OPEN_ISSUES["$n"]=1
+done < <(gh issue list -R "$REPO_FULL" --state open --limit 500 --json number --jq '.[].number')
+while IFS= read -r n; do
+  [[ -n "$n" ]] && CLOSED_ISSUES["$n"]=1
+done < <(gh issue list -R "$REPO_FULL" --state closed --limit 500 --json number --jq '.[].number')
+
+updated_done=0
+updated_todo=0
+assigned=0
+checked=0
+
+while IFS=$'\t' read -r item_id issue_n status assignees; do
+  [[ -z "$item_id" || -z "$issue_n" ]] && continue
+  checked=$((checked + 1))
+
+  target_status_id=""
+  target_flow_id=""
+
+  if [[ -n "${CLOSED_ISSUES[$issue_n]:-}" ]]; then
+    target_status_id="$status_done_id"
+    target_flow_id="$flow_done_id"
+  elif [[ -n "${OPEN_ISSUES[$issue_n]:-}" ]]; then
+    target_status_id="$status_todo_id"
+    target_flow_id="$flow_todo_id"
+  else
+    # Issue не найден (удалён/перенесён) — пропускаем.
+    continue
+  fi
+
+  current_status_name="${status:-}"
+  target_status_name="Todo"
+  [[ "$target_status_id" == "$status_done_id" ]] && target_status_name="Done"
+  [[ "$target_status_id" == "$status_todo_id" ]] && target_status_name="Todo/Backlog"
+
+  if [[ "$current_status_name" != "Done" && "$target_status_id" == "$status_done_id" ]]; then
+    gh project item-edit --id "$item_id" --project-id "$proj_id" \
+      --field-id "$status_field_id" --single-select-option-id "$status_done_id" >/dev/null
+    if [[ -n "$flow_field_id" && "$flow_field_id" != "null" && -n "$flow_done_id" && "$flow_done_id" != "null" ]]; then
+      gh project item-edit --id "$item_id" --project-id "$proj_id" \
+        --field-id "$flow_field_id" --single-select-option-id "$flow_done_id" >/dev/null
+    fi
+    updated_done=$((updated_done + 1))
+    echo "  ✓ #$issue_n -> Status Done"
+  elif [[ "$current_status_name" == "Done" && "$target_status_id" == "$status_todo_id" ]]; then
+    gh project item-edit --id "$item_id" --project-id "$proj_id" \
+      --field-id "$status_field_id" --single-select-option-id "$status_todo_id" >/dev/null
+    if [[ -n "$flow_field_id" && "$flow_field_id" != "null" && -n "$flow_todo_id" && "$flow_todo_id" != "null" ]]; then
+      gh project item-edit --id "$item_id" --project-id "$proj_id" \
+        --field-id "$flow_field_id" --single-select-option-id "$flow_todo_id" >/dev/null
+    fi
+    updated_todo=$((updated_todo + 1))
+    echo "  ✓ #$issue_n -> Status ${target_status_name}"
+  fi
+
+  if [[ -n "$ASSIGNEE" && -n "${OPEN_ISSUES[$issue_n]:-}" && -z "${assignees:-}" ]]; then
+    gh issue edit "$issue_n" -R "$REPO_FULL" --add-assignee "$ASSIGNEE" >/dev/null
+    assigned=$((assigned + 1))
+    echo "  ✓ #$issue_n -> assignee @$ASSIGNEE"
+  fi
+done < <(
+  echo "$items_json" | jq -r '
+    .items[]
+    | select(.content.type == "Issue")
+    | [.id, (.content.number|tostring), (.status // ""), ((.assignees // []) | join(","))]
+    | @tsv
+  '
+)
+
+echo ""
+echo "Синхронизация доски завершена:"
+echo "  - проверено карточек issue: $checked"
+echo "  - обновлено в Done: $updated_done"
+echo "  - обновлено в Todo/Backlog: $updated_todo"
+echo "  - назначено исполнителей: $assigned"
+
+echo ""
+echo "Open issues без checklist-подзадач:"
+missing=0
+while IFS=$'\t' read -r n title; do
+  [[ -z "$n" ]] && continue
+  missing=$((missing + 1))
+  echo "  - #$n $title"
+done < <(
+  gh issue list -R "$REPO_FULL" --state open --limit 500 --json number,title,body \
+    | jq -r '.[] | select((.body // "") | test("- \\[[ xX]\\]") | not) | [.number, .title] | @tsv'
+)
+if [[ "$missing" -eq 0 ]]; then
+  echo "  ✓ нет — у всех open issues есть чеклист."
+fi
+
+proj_url=$(gh project view "$proj_num" --owner "$OWNER" --format json 2>/dev/null | jq -r '.url // empty')
+[[ -z "$proj_url" || "$proj_url" == "null" ]] && proj_url="https://github.com/users/${OWNER}/projects/${proj_num}"
+echo ""
+echo "Доска: $proj_url"


### PR DESCRIPTION
## Summary
- add `scripts/github-project-sync.sh` for automatic Project hygiene
- sync board `Status`/`Поток` from issue state, assign open issues without assignee, and report open issues missing checklist subtasks
- document the command in ROADMAP EN/RU and CHANGELOG

## Test plan
- [x] Run `bash scripts/github-project-sync.sh --assign Gfermoto`
- [x] Verify output shows no remaining status drift and no open issues without checklist
- [ ] CI checks green on PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые возможности**
  * Добавлен скрипт для синхронизации доски GitHub Projects со статусом задач, автоматического назначения исполнителей открытым задачам и выявления задач без подпунктов списков.

* **Документация**
  * Обновлена документация с инструкциями по использованию скрипта синхронизации в разделах подготовки проекта и обработки отчётов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->