### PR TITLE
feat(overview): yearly species checklist / life list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **#54 (CI):** контрактный смоук OpenAPI — новый тест `app/web/tests/test_openapi_contract.py` и job `openapi-contract` в `.github/workflows/ci-pr.yml` (гейт на PR/push в `main`/`dev`).
+- **#55 (Overview):** yearly species checklist / life list — новый API `GET /api/ui/species/checklist/yearly?year=YYYY`, блок в Overview с выбором года и чеклистом «видел/не видел», плюс API-тесты и OpenAPI схема.
 
 ## [0.2.7] - 2026-03-23
 

--- a/app/ui/locales/de.json
+++ b/app/ui/locales/de.json
@@ -27,6 +27,11 @@
   "settings": {
     "save": "Einstellungen speichern"
   },
+  "overview": {
+    "yearlyChecklistTitle": "Arten-Checkliste pro Jahr",
+    "yearlyChecklistSummary": "{{seen}} von {{total}} Arten in diesem Jahr gesehen",
+    "year": "Jahr"
+  },
   "protected": {
     "passwordRequired": "Geben Sie das Admin-Passwort ein, um auf diesen Bereich zuzugreifen."
   }

--- a/app/ui/locales/en.json
+++ b/app/ui/locales/en.json
@@ -54,7 +54,10 @@
     "regionComparisonTopList": "Region top:",
     "regionComparisonHint": "Based on eBird data for the last 30 days. Region: {{region}}.",
     "regionComparisonConfigure": "Add eBird API key in Settings → Advanced for regional comparison.",
-    "regionComparisonNoData": "No observations in region {{region}} in the last 30 days. Check eBird country/state in settings."
+    "regionComparisonNoData": "No observations in region {{region}} in the last 30 days. Check eBird country/state in settings.",
+    "yearlyChecklistTitle": "Yearly Species Checklist",
+    "yearlyChecklistSummary": "Seen {{seen}} of {{total}} species this year",
+    "year": "Year"
   },
   "settings": {
     "section1": "1. Connection",

--- a/app/ui/locales/ru.json
+++ b/app/ui/locales/ru.json
@@ -54,7 +54,10 @@
     "regionComparisonTopList": "Топ региона:",
     "regionComparisonHint": "По данным eBird за последние 30 дней. Регион: {{region}}.",
     "regionComparisonConfigure": "Укажите ключ eBird API в Настройках → Расширенные для сравнения с регионом.",
-    "regionComparisonNoData": "В регионе {{region}} нет наблюдений за последние 30 дней. Проверьте eBird country/state в настройках."
+    "regionComparisonNoData": "В регионе {{region}} нет наблюдений за последние 30 дней. Проверьте eBird country/state в настройках.",
+    "yearlyChecklistTitle": "Чеклист видов за год",
+    "yearlyChecklistSummary": "За год отмечено {{seen}} из {{total}} видов",
+    "year": "Год"
   },
   "settings": {
     "section1": "1. Подключение",

--- a/app/ui/src/api/api.tsx
+++ b/app/ui/src/api/api.tsx
@@ -6,6 +6,7 @@ import {
   SpeciesSummary,
   OverviewData,
   Species,
+  YearlyChecklistData,
 } from '../types';
 import axios from 'axios';
 
@@ -587,6 +588,13 @@ export const fetchOverviewData = async (
       start_time: Math.floor(localStart.getTime() / 1000),
       end_time: Math.floor(localEnd.getTime() / 1000),
     },
+  });
+  return response.data;
+};
+
+export const fetchYearlyChecklist = async (year: number): Promise<YearlyChecklistData> => {
+  const response = await axios.get(`${BASE_API_URL}/species/checklist/yearly`, {
+    params: { year },
   });
   return response.data;
 };

--- a/app/ui/src/pages/Overview/index.tsx
+++ b/app/ui/src/pages/Overview/index.tsx
@@ -12,7 +12,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { useQuery } from '@tanstack/react-query';
-import { fetchOverviewData, fetchWeather, downloadReportPdf, fetchRegionComparison } from '../../api/api';
+import { fetchOverviewData, fetchWeather, downloadReportPdf, fetchRegionComparison, fetchYearlyChecklist } from '../../api/api';
 import { WeatherCard } from '../../components/WeatherCard';
 import { FeedCard } from '../../components/FeedCard';
 import { StatCard } from '../../components/StatCard';
@@ -29,6 +29,8 @@ import { PageHelp } from '../../components/PageHelp';
 import { overviewHelpConfig } from '../../page-help-config';
 import { useProtectedArea } from '../../contexts/ProtectedAreaContext';
 import Tooltip from '@mui/material/Tooltip';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 const formatHour = (hour: number) => {
   const date = new Date();
@@ -40,6 +42,7 @@ export const Overview = () => {
   const { t } = useTranslation();
   const { canEdit } = useProtectedArea();
   const [selectedDay, setSelectedDay] = useState<Dayjs>(dayjs());
+  const [checklistYear, setChecklistYear] = useState<Dayjs>(dayjs().startOf('year'));
   const [downloadingPdf, setDownloadingPdf] = useState(false);
 
   const {
@@ -63,6 +66,11 @@ export const Overview = () => {
     queryFn: () => fetchRegionComparison(),
     staleTime: 1000 * 60 * 10, // 10 min
     retry: false,
+  });
+
+  const { data: yearlyChecklist } = useQuery({
+    queryKey: ['yearly-checklist', checklistYear.year()],
+    queryFn: () => fetchYearlyChecklist(checklistYear.year()),
   });
 
   if (isLoadingSightings)
@@ -303,6 +311,53 @@ export const Overview = () => {
       </Grid>
 
       <Grid container spacing={2} sx={{ mt: 2 }}>
+        <Grid size={12}>
+          <Paper sx={{ p: 2 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5, gap: 1, flexWrap: 'wrap' }}>
+              <Typography variant="h6">{t('overview.yearlyChecklistTitle')}</Typography>
+              <LocalizationProvider dateAdapter={AdapterDayjs}>
+                <DatePicker
+                  label={t('overview.year')}
+                  views={['year']}
+                  value={checklistYear}
+                  onChange={(newValue) => {
+                    if (newValue) setChecklistYear(newValue.startOf('year'));
+                  }}
+                  disableFuture
+                />
+              </LocalizationProvider>
+            </Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+              {t('overview.yearlyChecklistSummary', {
+                seen: yearlyChecklist?.seen_species ?? 0,
+                total: yearlyChecklist?.total_species ?? 0,
+              })}
+            </Typography>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+                gap: 0.5,
+                maxHeight: 320,
+                overflowY: 'auto',
+              }}
+            >
+              {(yearlyChecklist?.items || []).map((item) => (
+                <FormControlLabel
+                  key={item.id}
+                  control={<Checkbox checked={item.seen} disabled size="small" />}
+                  label={
+                    item.seen
+                      ? `${item.name} (${item.count})`
+                      : item.name
+                  }
+                  sx={{ m: 0 }}
+                />
+              ))}
+            </Box>
+          </Paper>
+        </Grid>
+
         {/* Daily Pattern Chart */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper sx={{ p: 1, overflow: 'hidden' }}>

--- a/app/ui/src/types.ts
+++ b/app/ui/src/types.ts
@@ -258,6 +258,21 @@ export interface OverviewData {
   lastDetection?: OverviewLastDetection | null;
 }
 
+export interface YearlyChecklistItem {
+  id: number;
+  name: string;
+  seen: boolean;
+  count: number;
+  last_seen: string | null;
+}
+
+export interface YearlyChecklistData {
+  year: number;
+  total_species: number;
+  seen_species: number;
+  items: YearlyChecklistItem[];
+}
+
 export interface DetectionCounts {
   detections_24h: number;
   detections_7d: number;

--- a/app/web/openapi.yaml
+++ b/app/web/openapi.yaml
@@ -302,6 +302,33 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SpeciesSummary"
+  /species/checklist/yearly:
+    get:
+      summary: Yearly species checklist
+      description: |
+        Return a full species checklist for a specific year with seen/not-seen status and yearly count.
+        If `year` is omitted, current UTC year is used.
+      parameters:
+        - in: query
+          name: year
+          required: false
+          schema:
+            type: integer
+            minimum: 1970
+            maximum: 2100
+      responses:
+        "200":
+          description: Yearly checklist data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/YearlyChecklist"
+        "400":
+          description: Invalid year
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /bird_families:
     get:
       summary: Get all bird families
@@ -695,6 +722,34 @@ components:
           type: boolean
         count:
           type: integer
+    YearlyChecklistItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        seen:
+          type: boolean
+        count:
+          type: integer
+        last_seen:
+          type: string
+          format: date-time
+          nullable: true
+    YearlyChecklist:
+      type: object
+      properties:
+        year:
+          type: integer
+        total_species:
+          type: integer
+        seen_species:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/YearlyChecklistItem"
     BirdFamily:
       type: object
       properties:

--- a/app/web/routes/ui_routes.py
+++ b/app/web/routes/ui_routes.py
@@ -1135,6 +1135,77 @@ def register_routes(app):
         ).order_by(Species.name.asc()).all()
         return [{'id': s.id, 'name': s.name, 'count': int(cnt)} for s, cnt in rows]
 
+    @app.route('/api/ui/species/checklist/yearly', methods=['GET'])
+    def get_yearly_species_checklist():
+        """Yearly species checklist: all species with seen flag and yearly counts."""
+        year = request.args.get('year', type=int) or datetime.now(timezone.utc).year
+        if year < 1970 or year > 2100:
+            return {'error': 'year must be between 1970 and 2100'}, 400
+
+        start_dt = datetime(year, 1, 1, 0, 0, 0)
+        end_dt = datetime(year + 1, 1, 1, 0, 0, 0)
+
+        yearly_count_expr = func.coalesce(
+            func.sum(
+                case(
+                    (
+                        (SpeciesVisit.start_time >= start_dt)
+                        & (SpeciesVisit.start_time < end_dt),
+                        SpeciesVisit.max_simultaneous,
+                    ),
+                    else_=0,
+                )
+            ),
+            0,
+        )
+        last_seen_expr = func.max(
+            case(
+                (
+                    (SpeciesVisit.start_time >= start_dt)
+                    & (SpeciesVisit.start_time < end_dt),
+                    SpeciesVisit.start_time,
+                ),
+                else_=None,
+            )
+        )
+
+        rows = (
+            db.session.query(
+                Species.id,
+                Species.name,
+                yearly_count_expr.label('year_count'),
+                last_seen_expr.label('last_seen'),
+            )
+            .outerjoin(SpeciesVisit, Species.id == SpeciesVisit.species_id)
+            .group_by(Species.id, Species.name)
+            .order_by(Species.name.asc())
+            .all()
+        )
+
+        items = []
+        seen_species = 0
+        for row in rows:
+            year_count = int(row.year_count or 0)
+            seen = year_count > 0
+            if seen:
+                seen_species += 1
+            items.append(
+                {
+                    'id': row.id,
+                    'name': row.name,
+                    'seen': seen,
+                    'count': year_count,
+                    'last_seen': ensure_utc(row.last_seen).isoformat() if row.last_seen else None,
+                }
+            )
+
+        return {
+            'year': year,
+            'total_species': len(items),
+            'seen_species': seen_species,
+            'items': items,
+        }, 200
+
     @app.route('/api/ui/bird_families', methods=['GET'])
     def get_bird_families():
         """Get all bird families (categories one level below 'Birds')"""

--- a/app/web/tests/test_api.py
+++ b/app/web/tests/test_api.py
@@ -358,6 +358,27 @@ class TestSpecies:
         for item in r.json:
             assert 'id' in item and 'name' in item and 'count' in item
 
+    def test_yearly_checklist_returns_expected_shape(self, client):
+        r = client.get('/api/ui/species/checklist/yearly')
+        assert r.status_code == 200
+        data = r.json
+        assert 'year' in data
+        assert 'total_species' in data
+        assert 'seen_species' in data
+        assert 'items' in data
+        assert isinstance(data['items'], list)
+        for item in data['items']:
+            assert 'id' in item
+            assert 'name' in item
+            assert 'seen' in item
+            assert 'count' in item
+            assert 'last_seen' in item
+
+    def test_yearly_checklist_rejects_invalid_year(self, client):
+        r = client.get('/api/ui/species/checklist/yearly', query_string={'year': 3001})
+        assert r.status_code == 400
+        assert 'error' in r.json
+
 
 class TestBirdFamilies:
     def test_bird_families_returns_list(self, client):

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,7 +55,7 @@ Status/assignee/checklist sync: `bash scripts/github-project-sync.sh --assign Gf
 | 6 | UI i18n framework | [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52) ✅ locale switch + pilot `de` | `area:web`, P3 |
 | 7 | CI: scheduled image smoke test | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) ✅ workflow `Docker image smoke (published)` (`ghcr ... :latest` + `/api/ui/health`) | `area:infra`, P3 |
 | 8 | CI: OpenAPI contract tests | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) ✅ `openapi-contract` in CI + `web/tests/test_openapi_contract.py` | `area:web`, P3 |
-| 9 | Yearly species checklist / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) | `area:web`, P3 |
+| 9 | Yearly species checklist / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) ✅ API `GET /species/checklist/yearly` + Overview card (year picker, seen/not seen) | `area:web`, P3 |
 | 10 | CORS demo host → config/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | `area:web`, P3 |
 | 11 | Docs: Prometheus alert examples | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) ✅ `examples/prometheus/`, [CONFIGURATION](./CONFIGURATION.md) | `area:docs`, P3 |
 | 12 | Gallery: investigate / fix (opt-in public gallery) | [#80](https://github.com/Gfermoto/BirdLense-Hub/issues/80) ✅ app context in upload thread + docs/tests v0.2.4 | `area:web`, P2, `bug` |

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -57,7 +57,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 | 6 | i18n в UI | [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52) ✅ locale switch + пилотная `de` | P3, web |
 | 7 | CI: периодический smoke образа | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) ✅ workflow `Docker image smoke (published)` (`ghcr ... :latest` + `/api/ui/health`) | P3, infra |
 | 8 | CI: тесты контракта OpenAPI | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) ✅ `openapi-contract` в CI + `web/tests/test_openapi_contract.py` | P3, web |
-| 9 | Чеклист видов за год / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) | P3, web |
+| 9 | Чеклист видов за год / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) ✅ API `GET /species/checklist/yearly` + блок в Overview (выбор года, seen/not seen) | P3, web |
 | 10 | CORS demo → конфиг/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | P3, web |
 | 11 | Доки: примеры алертов Prometheus | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) ✅ `examples/prometheus/`, [CONFIGURATION](./CONFIGURATION.ru.md) | P3, docs |
 | 12 | Галерея: не работает — разбор и починка (opt-in) | [#80](https://github.com/Gfermoto/BirdLense-Hub/issues/80) ✅ app context в потоке загрузки + доки/тесты v0.2.4 | P2, web, bug |


### PR DESCRIPTION
## Summary
- add new API endpoint `GET /api/ui/species/checklist/yearly?year=YYYY` with seen/not-seen status, yearly count, and last seen timestamp for every species
- add Overview UI card with year picker and read-only checklist to track yearly/life-list progress
- cover endpoint in API tests, extend OpenAPI schema, and update ROADMAP/CHANGELOG

## Test plan
- [x] `cd /home/gfer/BirdLense/app/ui && npm run build`
- [x] `python3 -c \"from pathlib import Path; files=['app/web/routes/ui_routes.py','app/web/tests/test_api.py']; [compile(Path(f).read_text(encoding='utf-8'), f, 'exec') for f in files]; print('OK')\"`
- [ ] `cd /home/gfer/BirdLense && python3 -m pytest app/web/tests/test_api.py -q` (local env missing `sqlalchemy`)

Made with [Cursor](https://cursor.com)