### PR TITLE
feat(corrections): #81C unified history + #56 config-driven CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **#54 (CI):** контрактный смоук OpenAPI — новый тест `app/web/tests/test_openapi_contract.py` и job `openapi-contract` в `.github/workflows/ci-pr.yml` (гейт на PR/push в `main`/`dev`).
 - **#55 (Migration):** yearly species checklist / life list перенесён на страницу Migration и строится из уже существующих данных migration-таблицы (`/api/ui/migration-calendar`) за выбранный год; с главной страницы блок убран.
+- **#81 (phase C):** единый журнал ручных правок Unknowns/Video — backend activity `species_correction` + endpoint `GET /api/ui/corrections/recent` + блок последних правок на странице Unknowns.
+
+### Changed
+
+- **#56 (CORS config):** demo-host удалён из hardcoded CORS defaults; теперь базовые non-localhost origins задаются через `CORS_DEFAULT_ORIGINS` (и runtime `CORS_ORIGINS`), что безопаснее для self-hosting.
 
 ## [0.2.7] - 2026-03-23
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,6 +11,9 @@
 # Порт веб-интерфейса (по умолчанию 8085)
 # BIRDLENSE_PORT=8085
 
+# CORS — базовые origins по умолчанию (если нужен публичный домен/демо без runtime-переопределения)
+# CORS_DEFAULT_ORIGINS=https://demo.example.com,http://demo.example.com
+
 # CORS — доп. origins для доступа к API (через запятую)
 # CORS_ORIGINS=http://192.168.1.11:8085,http://192.168.1.11:80
 

--- a/app/ui/locales/en.json
+++ b/app/ui/locales/en.json
@@ -469,7 +469,10 @@
     "hourHint": "When selecting a time (not 00:00), only detections for that hour are shown.",
     "passwordRequired": "Enter settings password to correct species.",
     "corrected": "Species corrected",
-    "openVideoAfterCorrect": "Open video"
+    "openVideoAfterCorrect": "Open video",
+    "recentCorrectionsTitle": "Recent manual corrections (shared Unknowns/Video flow)",
+    "recentCorrectionConfirm": "Current species confirmed",
+    "recentCorrectionUpdate": "{{from}} -> {{to}}"
   },
   "species": {
     "searchPlaceholder": "Search species...",

--- a/app/ui/locales/ru.json
+++ b/app/ui/locales/ru.json
@@ -469,7 +469,10 @@
     "hourHint": "При выборе времени (не 00:00) показываются только детекции за выбранный час.",
     "passwordRequired": "Введите пароль настроек для исправления вида.",
     "corrected": "Вид исправлен",
-    "openVideoAfterCorrect": "Открыть видео"
+    "openVideoAfterCorrect": "Открыть видео",
+    "recentCorrectionsTitle": "Последние ручные правки (единый поток Unknowns/Video)",
+    "recentCorrectionConfirm": "Подтверждён текущий вид",
+    "recentCorrectionUpdate": "{{from}} → {{to}}"
   },
   "species": {
     "searchPlaceholder": "Поиск видов...",

--- a/app/ui/src/api/api.tsx
+++ b/app/ui/src/api/api.tsx
@@ -669,10 +669,11 @@ export const downloadReportPdf = async (month: string): Promise<void> => {
 export const updateDetectionSpecies = async (
   detectionId: number,
   speciesId: number,
+  source?: 'unknowns' | 'video',
 ): Promise<{ message: string; species_id: number; updated_count?: number }> => {
   const response = await axios.patch(
     `${BASE_API_URL}/detections/${detectionId}`,
-    { species_id: speciesId },
+    { species_id: speciesId, source },
     { withCredentials: true },
   );
   return response.data;
@@ -681,12 +682,32 @@ export const updateDetectionSpecies = async (
 /** Confirm detection: mark as verified (manually_corrected), remove from Unknowns. */
 export const confirmDetection = async (
   detectionId: number,
+  source?: 'unknowns' | 'video',
 ): Promise<{ message: string; updated_count: number }> => {
   const response = await axios.post(
     `${BASE_API_URL}/detections/${detectionId}/confirm`,
-    {},
+    { source },
     { withCredentials: true },
   );
+  return response.data;
+};
+
+export type CorrectionHistoryEntry = {
+  id: number;
+  created_at: string;
+  action: 'correct_species' | 'confirm_species';
+  source: 'unknowns' | 'video' | 'other';
+  detection_id: number | null;
+  from_species_name?: string | null;
+  to_species_name?: string | null;
+  updated_count?: number;
+};
+
+export const fetchRecentCorrections = async (limit = 10): Promise<CorrectionHistoryEntry[]> => {
+  const response = await axios.get(`${BASE_API_URL}/corrections/recent`, {
+    params: { limit },
+    withCredentials: true,
+  });
   return response.data;
 };
 

--- a/app/ui/src/pages/Unknowns/index.tsx
+++ b/app/ui/src/pages/Unknowns/index.tsx
@@ -27,6 +27,7 @@ import {
   fetchBirdDirectory,
   updateDetectionSpecies,
   confirmDetection,
+  fetchRecentCorrections,
   resolveImageUrl,
   type UnknownDetection,
 } from '../../api/api';
@@ -209,6 +210,11 @@ export function UnknownsPage() {
     queryKey: ['species'],
     queryFn: () => fetchBirdDirectory(),
   });
+  const { data: recentCorrections = [] } = useQuery({
+    queryKey: ['corrections-recent'],
+    queryFn: () => fetchRecentCorrections(8),
+    enabled: canEdit,
+  });
 
   const [correctError, setCorrectError] = useState<string | null>(null);
   const [correctSuccess, setCorrectSuccess] = useState<string | null>(null);
@@ -230,7 +236,7 @@ export function UnknownsPage() {
 
   const correctMutation = useMutation({
     mutationFn: ({ detectionId, speciesId }: { detectionId: number; speciesId: number }) =>
-      updateDetectionSpecies(detectionId, speciesId),
+      updateDetectionSpecies(detectionId, speciesId, 'unknowns'),
     onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['unknowns'] });
       queryClient.invalidateQueries({ queryKey: ['speciesVisits'] });
@@ -240,6 +246,7 @@ export function UnknownsPage() {
       queryClient.invalidateQueries({ queryKey: ['bird-directory'] });
       queryClient.invalidateQueries({ queryKey: ['species'] });
       queryClient.invalidateQueries({ queryKey: ['speciesSummary'] });
+      queryClient.invalidateQueries({ queryKey: ['corrections-recent'] });
       const msg = data?.updated_count && data.updated_count > 1
         ? t('video.correctedInVideos', { count: data.updated_count })
         : t('unknowns.corrected');
@@ -252,13 +259,14 @@ export function UnknownsPage() {
   });
 
   const confirmMutation = useMutation({
-    mutationFn: (detectionId: number) => confirmDetection(detectionId),
+    mutationFn: (detectionId: number) => confirmDetection(detectionId, 'unknowns'),
     onSuccess: (_data, detectionId) => {
       queryClient.invalidateQueries({ queryKey: ['unknowns'] });
       queryClient.invalidateQueries({ queryKey: ['speciesVisits'] });
       queryClient.invalidateQueries({ queryKey: ['overview'] });
       queryClient.invalidateQueries({ queryKey: ['timeline'] });
       queryClient.invalidateQueries({ queryKey: ['migration-calendar'] });
+      queryClient.invalidateQueries({ queryKey: ['corrections-recent'] });
       setSuccessVideoId(resolveVideoIdForDetection(detectionId));
       setCorrectSuccess(t('unknowns.corrected'));
     },
@@ -354,6 +362,27 @@ export function UnknownsPage() {
         }}
         onClose={() => setShowUnlockDialog(false)}
       />
+
+      {canEdit && recentCorrections.length > 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+            {t('unknowns.recentCorrectionsTitle')}
+          </Typography>
+          <Box component="ul" sx={{ m: 0, pl: 2 }}>
+            {recentCorrections.slice(0, 5).map((row) => (
+              <Typography component="li" variant="body2" key={row.id}>
+                {new Date(row.created_at).toLocaleString()} — {row.action === 'confirm_species'
+                  ? t('unknowns.recentCorrectionConfirm')
+                  : t('unknowns.recentCorrectionUpdate', {
+                      from: row.from_species_name || t('common.na'),
+                      to: row.to_species_name || t('common.na'),
+                    })}{' '}
+                ({row.source})
+              </Typography>
+            ))}
+          </Box>
+        </Alert>
+      )}
 
       {unknowns?.length === 0 ? (
         <Alert severity="info">{t('unknowns.empty')}</Alert>

--- a/app/ui/src/pages/VideoDetails/DetectedSpecies.tsx
+++ b/app/ui/src/pages/VideoDetails/DetectedSpecies.tsx
@@ -109,7 +109,7 @@ export const DetectedSpecies: React.FC<DetectedSpeciesProps> = ({
 
   const correctMutation = useMutation({
     mutationFn: ({ detectionId, speciesId }: { detectionId: number; speciesId: number }) =>
-      updateDetectionSpecies(detectionId, speciesId),
+      updateDetectionSpecies(detectionId, speciesId, 'video'),
     onSuccess: (data) => {
       if (videoId != null) queryClient.invalidateQueries({ queryKey: ['video', String(videoId)] });
       // Тот же API, что на странице Unknowns — иначе при staleTime 5m список «Неизвестные» остаётся старым.

--- a/app/web/app.py
+++ b/app/web/app.py
@@ -27,7 +27,8 @@ def create_app():
         os.getpid()
     )
     app = Flask(__name__)
-    # Базовые origins + CORS_ORIGINS из env (через запятую, для своих IP)
+    app.config.from_object('config.Config')
+    # Базовые origins + CORS_DEFAULT_ORIGINS/CORS_ORIGINS из env (через запятую, для своих IP/доменов)
     cors_origins = [
         "http://localhost:5173",
         "http://127.0.0.1:5173",
@@ -35,15 +36,14 @@ def create_app():
         "http://birdlense.local:80",
         "http://localhost:8085",
         "http://127.0.0.1:8085",
-        "http://192.168.1.11:8085",
-        "https://birdlense.eyera.info",
-        "http://birdlense.eyera.info",
     ]
-    extra = os.environ.get("CORS_ORIGINS", "")
-    if extra:
-        cors_origins.extend(s.strip() for s in extra.split(",") if s.strip())
+    default_extra = app.config.get("CORS_DEFAULT_ORIGINS", "")
+    if default_extra:
+        cors_origins.extend(s.strip() for s in default_extra.split(",") if s.strip())
+    runtime_extra = os.environ.get("CORS_ORIGINS", "")
+    if runtime_extra:
+        cors_origins.extend(s.strip() for s in runtime_extra.split(",") if s.strip())
     CORS(app, resources={r"/*": {"origins": cors_origins, "supports_credentials": True}})
-    app.config.from_object('config.Config')
 
     db.init_app(app)
     with app.app_context():

--- a/app/web/config.py
+++ b/app/web/config.py
@@ -29,3 +29,5 @@ class Config:
         'DATABASE_URL', f'sqlite:///{db_path}')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = _SECRET_KEY
+    # Optional built-in CORS origins (comma-separated). Keep empty by default for self-hosters.
+    CORS_DEFAULT_ORIGINS = os.getenv('CORS_DEFAULT_ORIGINS', '')

--- a/app/web/openapi.yaml
+++ b/app/web/openapi.yaml
@@ -393,6 +393,35 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /corrections/recent:
+    get:
+      summary: Get recent manual species corrections
+      description: |
+        Returns recent correction history entries for unified Unknowns and Video correction flow.
+        Requires contributor or admin access.
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Recent correction entries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CorrectionHistoryEntry"
+        "403":
+          description: Password required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /system/metrics:
     get:
       summary: Get system metrics
@@ -841,6 +870,33 @@ components:
           format: date
         totalUptime:
           type: number
+    CorrectionHistoryEntry:
+      type: object
+      properties:
+        id:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        action:
+          type: string
+          enum: [correct_species, confirm_species]
+        source:
+          type: string
+          enum: [unknowns, video, other]
+        detection_id:
+          type: integer
+          nullable: true
+        from_species_name:
+          type: string
+          nullable: true
+        to_species_name:
+          type: string
+          nullable: true
+        updated_count:
+          type: integer
+          nullable: true
     StorageStats:
       type: object
       properties:

--- a/app/web/routes/ui_routes.py
+++ b/app/web/routes/ui_routes.py
@@ -54,6 +54,30 @@ UNKNOWNS_LIMIT_MAX = 500
 
 
 def register_routes(app):
+    def _normalize_correction_source(value):
+        src = (value or '').strip().lower()
+        if src in ('unknowns', 'video'):
+            return src
+        return 'other'
+
+    def _write_correction_activity(action, source, detection_id, from_species_name=None, to_species_name=None, updated_count=None):
+        from models import ActivityLog
+        payload = {
+            'action': action,
+            'source': source,
+            'detection_id': detection_id,
+            'from_species_name': from_species_name,
+            'to_species_name': to_species_name,
+            'updated_count': updated_count,
+        }
+        try:
+            log = ActivityLog(type='species_correction', data=json_module.dumps(payload, ensure_ascii=False))
+            db.session.add(log)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            app.logger.exception('Failed to write species_correction activity log')
+
     @app.route('/api/ui/health', methods=['GET'])
     def health():
         return {'status': 'ok'}
@@ -905,6 +929,7 @@ def register_routes(app):
         """Подтвердить вид: пометить как проверенный (manually_corrected=True), убрать из Unknowns."""
         if not contributor_or_admin_access():
             return {'error': 'Password required'}, 403
+        source = _normalize_correction_source((request.json or {}).get('source'))
 
         vs = VideoSpecies.query.get(detection_id)
         if not vs:
@@ -915,8 +940,50 @@ def register_routes(app):
         for v in to_confirm:
             v.manually_corrected = True
         db.session.commit()
+        _write_correction_activity(
+            action='confirm_species',
+            source=source,
+            detection_id=detection_id,
+            from_species_name=vs.species.name,
+            to_species_name=vs.species.name,
+            updated_count=len(to_confirm),
+        )
 
         return {'message': 'Confirmed', 'updated_count': len(to_confirm)}, 200
+
+    @app.route('/api/ui/corrections/recent', methods=['GET'])
+    def recent_corrections():
+        if not contributor_or_admin_access():
+            return {'error': 'Password required'}, 403
+        from models import ActivityLog
+        limit = request.args.get('limit', 10, type=int)
+        limit = min(max(limit, 1), 100)
+        rows = (
+            ActivityLog.query
+            .filter_by(type='species_correction')
+            .order_by(ActivityLog.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+        out = []
+        for row in rows:
+            parsed = {}
+            if row.data:
+                try:
+                    parsed = json_module.loads(row.data)
+                except (TypeError, ValueError):
+                    parsed = {}
+            out.append({
+                'id': row.id,
+                'created_at': ensure_utc(row.created_at).isoformat() if row.created_at else None,
+                'action': parsed.get('action') or 'correct_species',
+                'source': parsed.get('source') or 'other',
+                'detection_id': parsed.get('detection_id'),
+                'from_species_name': parsed.get('from_species_name'),
+                'to_species_name': parsed.get('to_species_name'),
+                'updated_count': parsed.get('updated_count'),
+            })
+        return out, 200
 
     @app.route('/api/ui/detections/<int:detection_id>', methods=['PATCH'])
     def update_detection_species(detection_id):
@@ -925,6 +992,7 @@ def register_routes(app):
             return {'error': 'Password required'}, 403
 
         data = request.json or {}
+        source = _normalize_correction_source(data.get('source'))
         species_id = data.get('species_id')
         if species_id is None:
             return {'error': 'species_id is required'}, 400
@@ -1006,6 +1074,14 @@ def register_routes(app):
                     extract_and_save_crop_for_detection(v, species.name)
 
         updated_count = len(to_update)
+        _write_correction_activity(
+            action='correct_species',
+            source=source,
+            detection_id=detection_id,
+            from_species_name=old_species_name,
+            to_species_name=species.name,
+            updated_count=updated_count,
+        )
         return {
             'message': 'Species updated' + (f' ({updated_count} videos)' if updated_count > 1 else ''),
             'species_id': species_id,

--- a/app/web/tests/test_api.py
+++ b/app/web/tests/test_api.py
@@ -358,6 +358,19 @@ class TestSpecies:
         for item in r.json:
             assert 'id' in item and 'name' in item and 'count' in item
 
+
+class TestCorrectionsHistory:
+    def test_recent_corrections_endpoint_shape(self, client):
+        r = client.get('/api/ui/corrections/recent', query_string={'limit': 5})
+        assert r.status_code in (200, 403)
+        if r.status_code == 200:
+            assert isinstance(r.json, list)
+            for row in r.json:
+                assert 'id' in row
+                assert 'created_at' in row
+                assert 'action' in row
+                assert 'source' in row
+
 class TestBirdFamilies:
     def test_bird_families_returns_list(self, client):
         r = client.get('/api/ui/bird_families')

--- a/app/web/tests/test_config.py
+++ b/app/web/tests/test_config.py
@@ -1,0 +1,12 @@
+"""Config-level tests for environment-driven defaults."""
+import importlib
+
+
+def test_cors_default_origins_from_env(monkeypatch):
+    monkeypatch.setenv('CORS_DEFAULT_ORIGINS', 'https://demo.example,http://demo.local')
+    import config as config_module
+    importlib.reload(config_module)
+    assert (
+        config_module.Config.CORS_DEFAULT_ORIGINS
+        == 'https://demo.example,http://demo.local'
+    )

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -30,6 +30,7 @@ Defaults: `app/app_config/default_config.yaml`. User config is merged on top.
 | `PROCESSOR_SECRET` | Processor API protection (`X-Processor-Token`) |
 | `MCP_TOKEN` | MCP token (overrides `mcp.token`) |
 | `BIRDLENSE_PORT` | Nginx port (default 8085) |
+| `CORS_DEFAULT_ORIGINS` | Baseline CORS origins (comma-separated) for non-localhost defaults |
 | `CORS_ORIGINS` | Extra CORS origins (comma-separated) |
 | `OPENWEATHER_API_KEY` | OpenWeather key |
 | `MQTT_BROKER`, `MQTT_PASSWORD` | MQTT if not in config |

--- a/docs/CONFIGURATION.ru.md
+++ b/docs/CONFIGURATION.ru.md
@@ -30,6 +30,7 @@
 | `PROCESSOR_SECRET` | Защита API processor (X-Processor-Token) |
 | `MCP_TOKEN` | Токен MCP (переопределяет mcp.token) |
 | `BIRDLENSE_PORT` | Порт nginx (по умолчанию 8085) |
+| `CORS_DEFAULT_ORIGINS` | Базовые origins CORS (через запятую), если нужны не-localhost адреса по умолчанию |
 | `CORS_ORIGINS` | Доп. origins для CORS (через запятую) |
 | `OPENWEATHER_API_KEY` | Ключ OpenWeather |
 | `MQTT_BROKER`, `MQTT_PASSWORD` | MQTT (если не в конфиге) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,10 +56,10 @@ Status/assignee/checklist sync: `bash scripts/github-project-sync.sh --assign Gf
 | 7 | CI: scheduled image smoke test | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) ✅ workflow `Docker image smoke (published)` (`ghcr ... :latest` + `/api/ui/health`) | `area:infra`, P3 |
 | 8 | CI: OpenAPI contract tests | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) ✅ `openapi-contract` in CI + `web/tests/test_openapi_contract.py` | `area:web`, P3 |
 | 9 | Yearly species checklist / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) ✅ on Migration page, sourced from migration-table data for selected year | `area:web`, P3 |
-| 10 | CORS demo host → config/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | `area:web`, P3 |
+| 10 | CORS demo host → config/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) ✅ demo host moved out of hardcoded CORS defaults into `CORS_DEFAULT_ORIGINS` / `CORS_ORIGINS` | `area:web`, P3 |
 | 11 | Docs: Prometheus alert examples | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) ✅ `examples/prometheus/`, [CONFIGURATION](./CONFIGURATION.md) | `area:docs`, P3 |
 | 12 | Gallery: investigate / fix (opt-in public gallery) | [#80](https://github.com/Gfermoto/BirdLense-Hub/issues/80) ✅ app context in upload thread + docs/tests v0.2.4 | `area:web`, P2, `bug` |
-| 13 | Manual species correction: unify Unknowns vs in-video flow | [#81](https://github.com/Gfermoto/BirdLense-Hub/issues/81) 📝 Phases A + B in **v0.2.5** (Unknowns snackbar **Open video**); phase C on demand | `area:web`, P2 |
+| 13 | Manual species correction: unify Unknowns vs in-video flow | [#81](https://github.com/Gfermoto/BirdLense-Hub/issues/81) ✅ phases A+B+C: shared API + Unknowns **Open video** snackbar + recent shared correction history | `area:web`, P2 |
 | 14 | Video navigation: sequential browse (e.g. same day), no list reset | [#82](https://github.com/Gfermoto/BirdLense-Hub/issues/82) ✅ UI + `GET /videos/:id/neighbors` **v0.2.6** | `area:web`, P2 |
 | 15 | Video neighbors: local TZ, cross-day jump, docs clarity (follow-up to #82) | [#85](https://github.com/Gfermoto/BirdLense-Hub/issues/85) ✅ local day + `cross_day` + API/UI docs | `area:web`, P3 |
 | 16 | Overview: “mean duration” used visit span instead of per-recording average | [#107](https://github.com/Gfermoto/BirdLense-Hub/issues/107) ✅ mean over `Video` rows (PR [#106](https://github.com/Gfermoto/BirdLense-Hub/pull/106)); RU/EN labels | `area:web`, P3, `bug` |

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -58,10 +58,10 @@ bash scripts/github-project-add-backlog-consilium.sh
 | 7 | CI: периодический smoke образа | [#53](https://github.com/Gfermoto/BirdLense-Hub/issues/53) ✅ workflow `Docker image smoke (published)` (`ghcr ... :latest` + `/api/ui/health`) | P3, infra |
 | 8 | CI: тесты контракта OpenAPI | [#54](https://github.com/Gfermoto/BirdLense-Hub/issues/54) ✅ `openapi-contract` в CI + `web/tests/test_openapi_contract.py` | P3, web |
 | 9 | Чеклист видов за год / life list | [#55](https://github.com/Gfermoto/BirdLense-Hub/issues/55) ✅ на странице Migration, источник — данные migration-таблицы за выбранный год | P3, web |
-| 10 | CORS demo → конфиг/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) | P3, web |
+| 10 | CORS demo → конфиг/env | [#56](https://github.com/Gfermoto/BirdLense-Hub/issues/56) ✅ demo-host вынесен из hardcoded CORS defaults в `CORS_DEFAULT_ORIGINS` / `CORS_ORIGINS` | P3, web |
 | 11 | Доки: примеры алертов Prometheus | [#57](https://github.com/Gfermoto/BirdLense-Hub/issues/57) ✅ `examples/prometheus/`, [CONFIGURATION](./CONFIGURATION.ru.md) | P3, docs |
 | 12 | Галерея: не работает — разбор и починка (opt-in) | [#80](https://github.com/Gfermoto/BirdLense-Hub/issues/80) ✅ app context в потоке загрузки + доки/тесты v0.2.4 | P2, web, bug |
-| 13 | Ручная коррекция видов: связать «Неизвестные» и правки внутри видео | [#81](https://github.com/Gfermoto/BirdLense-Hub/issues/81) 📝 A + B в **v0.2.5** (snackbar «Открыть видео» на Unknowns); фаза C — по запросу | P2, web |
+| 13 | Ручная коррекция видов: связать «Неизвестные» и правки внутри видео | [#81](https://github.com/Gfermoto/BirdLense-Hub/issues/81) ✅ фазы A+B+C: единый API + snackbar «Открыть видео» + журнал последних ручных правок (Unknowns/Video) | P2, web |
 | 14 | Навигация по видео: подряд (напр. за день), без сброса в начало списка | [#82](https://github.com/Gfermoto/BirdLense-Hub/issues/82) ✅ UI + `GET /videos/:id/neighbors` **v0.2.6** | P2, web |
 | 15 | Соседи по видео: локальный TZ, переход на соседние сутки, ясность в доках (надстройка к #82) | [#85](https://github.com/Gfermoto/BirdLense-Hub/issues/85) ✅ локальный день + `cross_day` + доки API/UI | P3, web |
 | 16 | Overview: «Средняя длительность» считалась по визитам, а не по записям | [#107](https://github.com/Gfermoto/BirdLense-Hub/issues/107) ✅ среднее по `Video` (PR [#106](https://github.com/Gfermoto/BirdLense-Hub/pull/106)); подписи RU/EN | P3, web, bug |

--- a/docs/UX_UNKNOWN_VIDEO_CORRECTION.md
+++ b/docs/UX_UNKNOWN_VIDEO_CORRECTION.md
@@ -26,13 +26,13 @@ Manual species correction works well when one choice applies to **many** detecti
 |-------|--------|
 | **A — Docs & microcopy** | Page help + i18n: clarify that Unknowns and video use the **same** correction API; encourage View video for visual check. |
 | **B — Navigation** | From Unknowns after correct: optional “Stay on list” vs “Open video” — **implemented:** success snackbar includes **Open video** (default: stay on list; 10s auto-hide when action shown). |
-| **C — Unified history** (optional) | Activity log or “last corrected here / there” — only if operators ask. |
+| **C — Unified history** | **Implemented:** corrections write shared activity entries with `source` (`unknowns`/`video`) and Unknowns shows recent unified correction history. |
 
 ## Acceptance (from issue)
 
-- [ ] UX spec documented (this file + issue link).
-- [ ] Implementation or phased plan recorded in issue comments / PR.
-- [ ] No regression for bulk / multi-detection flows.
+- [x] UX spec documented (this file + issue link).
+- [x] Implementation or phased plan recorded in issue comments / PR.
+- [x] No regression for bulk / multi-detection flows.
 
 ---
 
@@ -40,4 +40,4 @@ Manual species correction works well when one choice applies to **many** detecti
 
 **Цель:** одна понятная история для оператора: исправление вида в «Неизвестных» и на странице видео — это **одно и то же действие** над детекцией (общий API), разные точки входа.
 
-**Фазы:** (A) тексты и справка, (B) опциональная навигация после исправления, (C) история/аудит по запросу.
+**Фазы:** (A) тексты и справка, (B) опциональная навигация после исправления, (C) единая история правок между Unknowns/Video.


### PR DESCRIPTION
## Summary
- implement #81 phase C: add shared correction history log (`species_correction`) with `source=unknowns|video|other`, expose `GET /api/ui/corrections/recent`, and show recent entries on Unknowns page
- pass correction source from both UI entry points (Unknowns and Video details) so operator flow is auditable and unified
- implement #56: move demo/public CORS defaults out of hardcoded app list into env/config (`CORS_DEFAULT_ORIGINS`, `CORS_ORIGINS`) with self-host-safe localhost defaults
- update OpenAPI, tests, UX/config docs, changelog and roadmap rows

## Test plan
- [x] `cd /home/gfer/BirdLense/app/ui && npm run build`
- [x] `python3 -c "from pathlib import Path; files=['app/web/app.py','app/web/config.py','app/web/routes/ui_routes.py','app/web/tests/test_api.py','app/web/tests/test_config.py']; [compile(Path(f).read_text(encoding='utf-8'), f, 'exec') for f in files]; print('OK')"`
- [ ] CI green

Closes #56
Closes #81

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена единая история ручных правок видов для страниц Unknowns и Video с новым эндпоинтом API для получения недавних корректировок.
  * На странице Unknowns отображается блок с последними пятью отредактированными записями.

* **Изменено**
  * Конфигурация CORS перенесена из жёстко закодированных значений в переменные окружения.

* **Документация**
  * Обновлены CHANGELOG, документация конфигурации и дорожная карта.
  * Добавлены строки локализации интерфейса для истории корректировок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->