### PR TITLE
docs(roadmap): link new planning issues #117-#121

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,11 +83,11 @@ Themes worth **Issues** when you are ready to schedule them (not on the consiliu
 
 | Theme | Why |
 |-------|-----|
-| **Accessibility (a11y)** | Keyboard navigation, focus order, contrast — natural follow-up after UI i18n ([#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)). |
-| **Broader E2E (Playwright)** | Beyond smoke: login, timeline, critical settings — tied to CI cost and flake budget. |
-| **Secrets in production** | Documented rotation / operational path for `secrets.*` and related keys (complements maintainer git scan [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
-| **Stack version sync** | After bumping Ultralytics, React, or base image — align **this doc**, `Dockerfile`, and release notes in one pass. |
-| **Community / donation UX** | Leaderboards, supporter badges, etc. — exploratory; `general.donate_url` already exists — [CONFIGURATION](./CONFIGURATION.md). |
+| **Accessibility (a11y)** | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117): keyboard navigation, focus order, contrast for Unknowns/Video/Migration (follow-up after i18n [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)). |
+| **Broader E2E (Playwright)** | [#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118): beyond smoke — login, timeline, critical settings, correction flow. |
+| **Secrets in production** | [#119](https://github.com/Gfermoto/BirdLense-Hub/issues/119): documented rotation / operational path for `secrets.*` and related keys (complements [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
+| **Stack version sync** | [#120](https://github.com/Gfermoto/BirdLense-Hub/issues/120): checklist to align VERSION/Docker/docs/release notes after dependency bumps. |
+| **Community / donation UX** | [#121](https://github.com/Gfermoto/BirdLense-Hub/issues/121): support UX experiments with minimal operator-flow noise; `general.donate_url` already exists. |
 
 ---
 

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -85,11 +85,11 @@ bash scripts/github-project-add-backlog-consilium.sh
 
 | Тема | Зачем |
 |------|--------|
-| **Доступность (a11y)** | Клавиатура, фокус, контраст — логично после i18n ([#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)). |
-| **Расширение E2E (Playwright)** | Не только смоук: логин, таймлайн, критичные настройки — баланс с CI и стабильностью. |
-| **Секреты в проде** | Документированная ротация / операционный путь для `secrets.*` (дополняет [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
-| **Синхронизация версий стека** | После bump Ultralytics/React/base image — **этот док**, Docker и release notes одним проходом. |
-| **Community / донаты в UI** | Лидерборды, бейджи поддержки и т.п. — на стадии идей; ссылка на донаты уже есть: `general.donate_url` — [CONFIGURATION](./CONFIGURATION.ru.md). |
+| **Доступность (a11y)** | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117): клавиатура, фокус, контраст для Unknowns/Video/Migration после i18n ([#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)). |
+| **Расширение E2E (Playwright)** | [#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118): не только смоук — логин, таймлайн, критичные настройки, коррекция видов. |
+| **Секреты в проде** | [#119](https://github.com/Gfermoto/BirdLense-Hub/issues/119): документированная ротация / операционный путь для `secrets.*` (дополняет [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
+| **Синхронизация версий стека** | [#120](https://github.com/Gfermoto/BirdLense-Hub/issues/120): чеклист sync VERSION/Docker/docs/release notes после bump зависимостей. |
+| **Community / донаты в UI** | [#121](https://github.com/Gfermoto/BirdLense-Hub/issues/121): UX-эксперименты поддержки проекта при сохранении ненавязчивости; базовая ссылка уже есть: `general.donate_url`. |
 
 ---
 


### PR DESCRIPTION
## Summary
- create issue links for all previous non-issue roadmap candidates (#117-#121)
- update RU/EN roadmap candidate tables to point to concrete tracked tasks
- keep planning transparent in project board and roadmap docs

## Test plan
- [x] Docs-only change, markdown table links reviewed
- [ ] CI green

Made with [Cursor](https://cursor.com)