### PR TITLE
docs(roadmap): clarify #131 Migration as catalog entry

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,7 +100,7 @@ Tracked as separate issues; acceptance criteria live in each issue.
 | [#128](https://github.com/Gfermoto/BirdLense-Hub/issues/128) | Auto thresholds for regional top | `species_confidence_overrides` from eBird top (delta must be in 0–1 scale, not literal −0.5) |
 | [#129](https://github.com/Gfermoto/BirdLense-Hub/issues/129) | Thresholds + MQTT BirdNET | Extra sensitivity; **7-day** hint window (when BirdNET is configured) |
 | [#130](https://github.com/Gfermoto/BirdLense-Hub/issues/130) | Overview second chart | Click species → today’s recordings for that species |
-| [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) | Migration + catalog UX | Clickable species → species page; **tabs** switch sort/mode; full catalog merge optional |
+| [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) | Migration as catalog entry | Fewer nav tabs; migration table primary path to species; clicks → `/species/:id`; in-page tabs = table modes |
 | [#132](https://github.com/Gfermoto/BirdLense-Hub/issues/132) | Species filters | Regional = eBird top + BirdNET-heard |
 | [#133](https://github.com/Gfermoto/BirdLense-Hub/issues/133) | Period on Migration | **Day-level date range**; table + heard/recognized; not regional |
 | [#134](https://github.com/Gfermoto/BirdLense-Hub/issues/134) | Food list for Europe | Expand seed + document source (`seed.py`) |

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -102,7 +102,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 | [#128](https://github.com/Gfermoto/BirdLense-Hub/issues/128) | Авто-пороги для топа региона | `species_confidence_overrides` из eBird top (нужна дельта в 0–1, не «минус 0.5» буквально) |
 | [#129](https://github.com/Gfermoto/BirdLense-Hub/issues/129) | Пороги + MQTT BirdNET | Доп. снижение порога; окно подсказок **7 дней** (если BirdNET настроен) |
 | [#130](https://github.com/Gfermoto/BirdLense-Hub/issues/130) | Overview, вторая диаграмма | Клик по виду → записи этого вида за сегодня |
-| [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) | Migration + каталог | Кликабельные виды в таблице → страница вида; **вкладки** меняют сортировку/режим таблицы (не обязательно переносить весь каталог) |
+| [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) | Migration = вход в каталог | Меньше вкладок в меню; таблица миграции — главный вход к видам; клики → `/species/:id`; режимы таблицы — вкладки на странице |
 | [#132](https://github.com/Gfermoto/BirdLense-Hub/issues/132) | Фильтры видов | Региональные = топ eBird + услышанные BirdNET |
 | [#133](https://github.com/Gfermoto/BirdLense-Hub/issues/133) | Период на Migration | **Диапазон с точностью до дня**; таблица + услышанные/распознанные; не на регион |
 | [#134](https://github.com/Gfermoto/BirdLense-Hub/issues/134) | Корм для Европы | Расширить seed + документация источника (`seed.py`) |


### PR DESCRIPTION
Updates ROADMAP RU/EN row for #131: fewer nav tabs, migration table as primary path to species.

Made with [Cursor](https://cursor.com)