### PR TITLE
feat: finalize #131 species entry via migration

### DIFF
--- a/app/e2e/tests/smoke.spec.ts
+++ b/app/e2e/tests/smoke.spec.ts
@@ -48,6 +48,12 @@ test.describe('Smoke tests', () => {
     });
   });
 
+  test('Species legacy URL redirects to migration page', async ({ page }) => {
+    await page.goto('/species', { waitUntil: 'networkidle' });
+    await expect(page).toHaveURL(/\/migration-calendar/);
+    await expect(page.getByText(/Migration|Мигра/i).first()).toBeVisible({ timeout: 15000 });
+  });
+
   test('System page loads', async ({ page }) => {
     await page.goto('/system', { waitUntil: 'networkidle' });
     await expect(page.getByText(/System|Система/i).first()).toBeVisible({ timeout: 15000 });

--- a/app/ui/src/App.tsx
+++ b/app/ui/src/App.tsx
@@ -21,9 +21,6 @@ const VideoDetails = lazy(() =>
 const FoodManagement = lazy(() =>
   import('./pages/FoodManagement').then((m) => ({ default: m.FoodManagement })),
 );
-const BirdDirectory = lazy(() =>
-  import('./pages/BirdDirectory').then((m) => ({ default: m.BirdDirectory })),
-);
 const LivePage = lazy(() => import('./pages/Live').then((m) => ({ default: m.LivePage })));
 const Settings = lazy(() => import('./pages/Settings').then((m) => ({ default: m.Settings })));
 const SpeciesSummary = lazy(() => import('./pages/SpeciesSummary'));
@@ -155,7 +152,7 @@ function App() {
                     <Route path="/migration-calendar" element={<MigrationCalendar />} />
                     <Route path="/videos/:id" element={<VideoDetails />} />
                     <Route path="/food" element={<FoodManagement />} />
-                    <Route path="/species" element={<BirdDirectory />} />
+                    <Route path="/species" element={<Navigate to="/migration-calendar" replace />} />
                     <Route path="/live" element={<LivePage />} />
                     <Route path="/settings" element={<Settings />} />
                     <Route path="/species/:id" element={<SpeciesSummary />} />

--- a/app/ui/src/pages/SpeciesSummary/index.tsx
+++ b/app/ui/src/pages/SpeciesSummary/index.tsx
@@ -166,7 +166,7 @@ const SpeciesSummaryPage = () => {
         <Alert severity="warning" sx={{ mb: 2 }}>
           {t('speciesSummary.invalidId')}
         </Alert>
-        <Button variant="contained" component={RouterLink} to="/species">
+        <Button variant="contained" component={RouterLink} to="/migration-calendar">
           {t('speciesSummary.openDirectory')}
         </Button>
       </Box>
@@ -189,7 +189,7 @@ const SpeciesSummaryPage = () => {
         <Button variant="outlined" sx={{ mr: 1 }} onClick={() => refetch()}>
           {t('common.retry')}
         </Button>
-        <Button variant="contained" component={RouterLink} to="/species">
+        <Button variant="contained" component={RouterLink} to="/migration-calendar">
           {t('speciesSummary.openDirectory')}
         </Button>
       </Box>


### PR DESCRIPTION
## Summary
- finalize #131 routing by making legacy `/species` redirect to `/migration-calendar`
- align Species Summary fallback actions with the new primary entry (`/migration-calendar`)
- add smoke coverage for `/species` legacy redirect behavior

## Test plan
- [x] `npm run build` (in `app/ui`)
- [x] `BASE_URL=\"https://birdlense.eyera.info\" npm test -- --grep \"Species legacy URL redirects to migration page|Unknowns legacy URL redirects to timeline review mode\"` (in `app/e2e`)
- [x] `make deploy` + post-deploy health check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Тесты**
  * Добавлены проверки корректного перенаправления унаследованных URL-адресов.

* **Рефакторинг**
  * Маршрут `/species` теперь автоматически перенаправляется на страницу календаря миграции. Обновлены навигационные элементы для согласованности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->