### PR TITLE
fix: keep timeline review counter inside chip

### DIFF
--- a/app/ui/src/pages/Timeline/index.tsx
+++ b/app/ui/src/pages/Timeline/index.tsx
@@ -33,7 +33,6 @@ import { timelineHelpConfig } from '../../page-help-config';
 import { getTimeRange, type TimeOfDay } from '../../utils/timeUtils';
 import { useProtectedArea } from '../../contexts/ProtectedAreaContext';
 import Chip from '@mui/material/Chip';
-import Badge from '@mui/material/Badge';
 import { UnknownsPage } from '../Unknowns';
 
 function useSpeciesList(visits: SpeciesVisit[] | undefined) {
@@ -190,15 +189,32 @@ export function TimelinePage() {
           variant={isReviewMode ? 'filled' : 'outlined'}
           aria-pressed={isReviewMode}
           onClick={() => navigate('/timeline?review=1')}
+          sx={{ px: 0.5 }}
           label={
-            <Badge
-              badgeContent={unknownsCount}
-              color="warning"
-              max={500}
-              invisible={unknownsCount === 0}
-            >
-              {t('timeline.modeReview')}
-            </Badge>
+            <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}>
+              <Box component="span">{t('timeline.modeReview')}</Box>
+              {unknownsCount > 0 && (
+                <Box
+                  component="span"
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minWidth: 20,
+                    height: 20,
+                    px: 0.75,
+                    borderRadius: 10,
+                    bgcolor: 'warning.main',
+                    color: 'warning.contrastText',
+                    fontSize: 12,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                  }}
+                >
+                  {Math.min(unknownsCount, 500)}
+                </Box>
+              )}
+            </Box>
           }
         />
       </Box>


### PR DESCRIPTION
## Summary
- fix `На проверке`/Review chip counter alignment on Timeline
- move count indicator inside chip label at the right edge instead of using an externally positioned badge
- add horizontal chip padding to prevent clipping in compact layouts

## Related
- closes #144

## Test plan
- [x] `npm run build` (app/ui)
- [x] `make deploy`
- [x] `BASE_URL=\"https://birdlense.eyera.info\" npm test -- --grep \"Unknowns legacy URL redirects to timeline review mode\"` (app/e2e)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Обновлена визуализация индикатора режима рецензирования в Timeline с добавлением счётчика неизвестных элементов (максимум 500).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->