### PR TITLE
feat: move region comparison block to migration

### DIFF
--- a/app/e2e/tests/smoke.spec.ts
+++ b/app/e2e/tests/smoke.spec.ts
@@ -40,6 +40,13 @@ test.describe('Smoke tests', () => {
     await expect(page.getByText(/Timeline|Записи|Select/i).first()).toBeVisible({ timeout: 15000 });
   });
 
+  test('Migration page shows region comparison block', async ({ page }) => {
+    await page.goto('/migration-calendar', { waitUntil: 'networkidle' });
+    await expect(page.getByText(/Region Comparison|Сравнение с регионом/i).first()).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
   test('Unknowns legacy URL redirects to timeline review mode', async ({ page }) => {
     await page.goto('/unknowns', { waitUntil: 'networkidle' });
     await expect(page).toHaveURL(/\/timeline\?review=1/);

--- a/app/ui/locales/en.json
+++ b/app/ui/locales/en.json
@@ -54,7 +54,8 @@
     "regionComparisonTopList": "Region top:",
     "regionComparisonHint": "Based on eBird data for the last 30 days. Region: {{region}}.",
     "regionComparisonConfigure": "Add eBird API key in Settings → Advanced for regional comparison.",
-    "regionComparisonNoData": "No observations in region {{region}} in the last 30 days. Check eBird country/state in settings."
+    "regionComparisonNoData": "No observations in region {{region}} in the last 30 days. Check eBird country/state in settings.",
+    "regionComparisonMoved": "Regional top and overlap moved to the Migration page."
   },
   "settings": {
     "section1": "1. Connection",

--- a/app/ui/locales/ru.json
+++ b/app/ui/locales/ru.json
@@ -54,7 +54,8 @@
     "regionComparisonTopList": "Топ региона:",
     "regionComparisonHint": "По данным eBird за последние 30 дней. Регион: {{region}}.",
     "regionComparisonConfigure": "Укажите ключ eBird API в Настройках → Расширенные для сравнения с регионом.",
-    "regionComparisonNoData": "В регионе {{region}} нет наблюдений за последние 30 дней. Проверьте eBird country/state в настройках."
+    "regionComparisonNoData": "В регионе {{region}} нет наблюдений за последние 30 дней. Проверьте eBird country/state в настройках.",
+    "regionComparisonMoved": "Топ региона и пересечение перенесены на страницу «Миграции»."
   },
   "settings": {
     "section1": "1. Подключение",

--- a/app/ui/src/pages/MigrationCalendar/index.tsx
+++ b/app/ui/src/pages/MigrationCalendar/index.tsx
@@ -16,7 +16,7 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import { useTranslation } from 'react-i18next';
 import FilterListIcon from '@mui/icons-material/FilterList';
-import { fetchMigrationCalendar } from '../../api/api';
+import { fetchMigrationCalendar, fetchRegionComparison } from '../../api/api';
 import { SpeciesIcon } from '../../components/SpeciesIcon';
 import { PageHelp } from '../../components/PageHelp';
 
@@ -42,6 +42,13 @@ export const MigrationCalendar = () => {
   const { data, isLoading, error } = useQuery({
     queryKey: ['migration-calendar', params],
     queryFn: () => fetchMigrationCalendar(params),
+  });
+
+  const { data: regionComparison } = useQuery({
+    queryKey: ['region-comparison'],
+    queryFn: () => fetchRegionComparison(),
+    staleTime: 1000 * 60 * 10, // 10 min
+    retry: false,
   });
 
   if (isLoading) {
@@ -167,6 +174,91 @@ export const MigrationCalendar = () => {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <Paper sx={{ p: 2, mt: 2 }}>
+        <Typography variant="h6" gutterBottom>
+          {t('overview.regionComparison')}
+        </Typography>
+        {regionComparison?.regionCode && regionComparison.regionTopCount > 0 ? (
+          <>
+            <Typography variant="body1">
+              {t('overview.regionComparisonDesc', {
+                userCount: regionComparison.userCount,
+                regionTop: regionComparison.regionTopCount,
+                matchCount: regionComparison.matchCount,
+              })}
+            </Typography>
+            {regionComparison.matchedSpecies?.length > 0 && (
+              <Box sx={{ mt: 1.5 }}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  {t('overview.regionComparisonMatched')}
+                </Typography>
+                <Box
+                  component="ul"
+                  sx={{
+                    m: 0,
+                    pl: 2.5,
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 0.5,
+                    '& li': { display: 'inline' },
+                    '& li:not(:last-child)::after': { content: '" · "', color: 'text.secondary' },
+                  }}
+                >
+                  {regionComparison.matchedSpecies.map((name) => (
+                    <li key={name}>
+                      <Typography component="span" variant="body2" fontWeight={500}>
+                        {name}
+                      </Typography>
+                    </li>
+                  ))}
+                </Box>
+              </Box>
+            )}
+            {regionComparison.regionTop?.length > 0 && (
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                  {t('overview.regionComparisonTopList')}
+                </Typography>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 0.75,
+                  }}
+                >
+                  {regionComparison.regionTop.map((name, idx) => (
+                    <Typography
+                      key={name}
+                      component="span"
+                      variant="body2"
+                      sx={{
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: 1,
+                        bgcolor: 'action.hover',
+                      }}
+                    >
+                      {idx + 1}. {name}
+                    </Typography>
+                  ))}
+                </Box>
+              </Box>
+            )}
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
+              {t('overview.regionComparisonHint', { region: regionComparison.regionCode })}
+            </Typography>
+          </>
+        ) : regionComparison?.regionCode ? (
+          <Typography variant="body2" color="text.secondary">
+            {t('overview.regionComparisonNoData', { region: regionComparison.regionCode })}
+          </Typography>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            {t('overview.regionComparisonConfigure')}
+          </Typography>
+        )}
+      </Paper>
     </Box>
   );
 };

--- a/app/ui/src/pages/Overview/index.tsx
+++ b/app/ui/src/pages/Overview/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -12,7 +13,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { useQuery } from '@tanstack/react-query';
-import { fetchOverviewData, fetchWeather, downloadReportPdf, fetchRegionComparison } from '../../api/api';
+import { fetchOverviewData, fetchWeather, downloadReportPdf } from '../../api/api';
 import { WeatherCard } from '../../components/WeatherCard';
 import { FeedCard } from '../../components/FeedCard';
 import { StatCard } from '../../components/StatCard';
@@ -29,6 +30,7 @@ import { PageHelp } from '../../components/PageHelp';
 import { overviewHelpConfig } from '../../page-help-config';
 import { useProtectedArea } from '../../contexts/ProtectedAreaContext';
 import Tooltip from '@mui/material/Tooltip';
+import Link from '@mui/material/Link';
 
 const formatHour = (hour: number) => {
   const date = new Date();
@@ -56,13 +58,6 @@ export const Overview = () => {
   const { data: weather, error: errorWeather, refetch: refetchWeather } = useQuery({
     queryKey: ['weather'],
     queryFn: () => fetchWeather(),
-  });
-
-  const { data: regionComparison } = useQuery({
-    queryKey: ['region-comparison'],
-    queryFn: () => fetchRegionComparison(),
-    staleTime: 1000 * 60 * 10, // 10 min
-    retry: false,
   });
 
   if (isLoadingSightings)
@@ -339,91 +334,19 @@ export const Overview = () => {
           </Paper>
         </Grid>
 
-        {/* Region Comparison — в конце страницы, на всю ширину */}
+        {/* Region comparison moved to Migration page */}
         <Grid size={12} sx={{ mt: 3 }}>
           <Paper sx={{ p: 2 }}>
             <Typography variant="h6" gutterBottom>
               {t('overview.regionComparison')}
             </Typography>
-            {regionComparison?.regionCode && regionComparison.regionTopCount > 0 ? (
-              <>
-                <Typography variant="body1">
-                  {t('overview.regionComparisonDesc', {
-                    userCount: regionComparison.userCount,
-                    regionTop: regionComparison.regionTopCount,
-                    matchCount: regionComparison.matchCount,
-                  })}
-                </Typography>
-                {regionComparison.matchedSpecies?.length > 0 && (
-                  <Box sx={{ mt: 1.5 }}>
-                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                      {t('overview.regionComparisonMatched')}
-                    </Typography>
-                    <Box
-                      component="ul"
-                      sx={{
-                        m: 0,
-                        pl: 2.5,
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: 0.5,
-                        '& li': { display: 'inline' },
-                        '& li:not(:last-child)::after': { content: '" · "', color: 'text.secondary' },
-                      }}
-                    >
-                      {regionComparison.matchedSpecies.map((name) => (
-                        <li key={name}>
-                          <Typography component="span" variant="body2" fontWeight={500}>
-                            {name}
-                          </Typography>
-                        </li>
-                      ))}
-                    </Box>
-                  </Box>
-                )}
-                {regionComparison.regionTop?.length > 0 && (
-                  <Box sx={{ mt: 2 }}>
-                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                      {t('overview.regionComparisonTopList')}
-                    </Typography>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        flexWrap: 'wrap',
-                        gap: 0.75,
-                      }}
-                    >
-                      {regionComparison.regionTop.map((name, idx) => (
-                        <Typography
-                          key={name}
-                          component="span"
-                          variant="body2"
-                          sx={{
-                            px: 1,
-                            py: 0.25,
-                            borderRadius: 1,
-                            bgcolor: 'action.hover',
-                          }}
-                        >
-                          {idx + 1}. {name}
-                        </Typography>
-                      ))}
-                    </Box>
-                  </Box>
-                )}
-                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 1 }}>
-                  {t('overview.regionComparisonHint', { region: regionComparison.regionCode })}
-                </Typography>
-              </>
-            ) : regionComparison?.regionCode ? (
-              <Typography variant="body2" color="text.secondary">
-                {t('overview.regionComparisonNoData', { region: regionComparison.regionCode })}
-              </Typography>
-            ) : (
-              <Typography variant="body2" color="text.secondary">
-                {t('overview.regionComparisonConfigure')}
-              </Typography>
-            )}
+            <Typography variant="body2" color="text.secondary">
+              {t('overview.regionComparisonMoved')}{' '}
+              <Link component={RouterLink} to="/migration-calendar" underline="hover">
+                {t('nav.migrationCalendar')}
+              </Link>
+              .
+            </Typography>
           </Paper>
         </Grid>
       </Grid>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -97,9 +97,9 @@ Tracked as separate issues; acceptance criteria live in each issue.
 **Preparation before coding ([#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131), [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139)):** [pre-implementation checklist](./PRE_IMPLEMENTATION_UNKNOWN_TIMELINE.md).
 
 **Progress update (Mar 2026):**
-- [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — increment 1/2 shipped in code: Unknowns nav removed, `/unknowns` legacy redirect to `/timeline?review=1`, Timeline review mode (chip + badge), OpenAPI + API tests + smoke redirect test.
-- [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — navigation part shipped in code: Catalog nav entry removed; Migration remains the primary path to species (`/species/:id` deep links intact).
-- Increment 3 (docs + final validation/deploy + issue/board reporting) is in progress.
+- [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — shipped and closed: Unknowns nav removed, `/unknowns` legacy redirect to `/timeline?review=1`, Timeline review mode (chip + counter), OpenAPI + API tests + smoke redirect coverage.
+- [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — shipped and closed: Catalog menu entry removed, legacy `/species` redirects to `/migration-calendar`, species deep links (`/species/:id`) preserved.
+- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — in progress: region comparison block moved from Overview to Migration; Overview now shows a short pointer to Migration.
 
 | # | Issue | Summary |
 |---|--------|--------|

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -99,9 +99,9 @@ bash scripts/github-project-add-backlog-consilium.sh
 **Подготовка перед реализацией ([#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131), [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139)):** [чеклист](./PRE_IMPLEMENTATION_UNKNOWN_TIMELINE.ru.md).
 
 **Прогресс (март 2026):**
-- [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — инкременты 1/2 уже в коде: убран пункт «Неизвестные» из меню, legacy-редирект `/unknowns` → `/timeline?review=1`, режим «На проверке» на Timeline (чип + бейдж), обновлены OpenAPI + API тесты + smoke-тест редиректа.
-- [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — навигационная часть уже в коде: пункт «Каталог» убран из меню; Migration остаётся основным входом к видам (deep-link `/species/:id` сохранён).
-- Инкремент 3 (документация + финальная проверка/деплой + отчётность в issue/доске) в работе.
+- [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — реализовано и закрыто: убран пункт «Неизвестные», legacy-редирект `/unknowns` → `/timeline?review=1`, режим «На проверке» на Timeline (чип + счётчик), обновлены OpenAPI + API тесты + smoke редиректа.
+- [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — реализовано и закрыто: пункт «Каталог» убран из меню, legacy `/species` редиректит на `/migration-calendar`, deep-link `/species/:id` сохранён.
+- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — в работе: блок «Сравнение с регионом» перенесён с Overview на Migration; на Overview оставлена короткая ссылка-переход.
 
 | # | Issue | Кратко |
 |---|--------|--------|


### PR DESCRIPTION
## Summary
- implement #127 by moving the regional top/overlap block from Overview to Migration
- keep discoverability: Overview now shows a short pointer link to the Migration page
- update EN/RU roadmap progress and add smoke test for the new Migration location

## Test plan
- [x] `npm run build` (app/ui)
- [x] `make deploy`
- [x] `BASE_URL=\"https://birdlense.eyera.info\" npm test -- --grep \"Migration page shows region comparison block|Overview page loads\"` (app/e2e)

## Related
- closes #127

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Функция сравнения с регионом перемещена на страницу "Календарь миграций"
  * На странице "Обзор" добавлено информационное сообщение с ссылкой на новое расположение

* **Тесты**
  * Добавлены автоматические тесты для проверки функции сравнения с регионом

* **Документация**
  * Обновлена информация о ходе выполнения работ в дорожной карте продукта

<!-- end of auto-generated comment: release notes by coderabbit.ai -->