### PR TITLE
fix: remove overview leftover note and normalize food stats

### DIFF
--- a/app/ui/src/pages/Overview/index.tsx
+++ b/app/ui/src/pages/Overview/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link as RouterLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -30,7 +29,6 @@ import { PageHelp } from '../../components/PageHelp';
 import { overviewHelpConfig } from '../../page-help-config';
 import { useProtectedArea } from '../../contexts/ProtectedAreaContext';
 import Tooltip from '@mui/material/Tooltip';
-import Link from '@mui/material/Link';
 
 const formatHour = (hour: number) => {
   const date = new Date();
@@ -334,21 +332,6 @@ export const Overview = () => {
           </Paper>
         </Grid>
 
-        {/* Region comparison moved to Migration page */}
-        <Grid size={12} sx={{ mt: 3 }}>
-          <Paper sx={{ p: 2 }}>
-            <Typography variant="h6" gutterBottom>
-              {t('overview.regionComparison')}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {t('overview.regionComparisonMoved')}{' '}
-              <Link component={RouterLink} to="/migration-calendar" underline="hover">
-                {t('nav.migrationCalendar')}
-              </Link>
-              .
-            </Typography>
-          </Paper>
-        </Grid>
       </Grid>
     </Box>
   );

--- a/app/web/services/species_summary_service.py
+++ b/app/web/services/species_summary_service.py
@@ -59,16 +59,27 @@ def build_species_summary(session, species, children, all_species_ids: list) -> 
         Video.weather_temp.isnot(None),
     ).group_by(func.round(Video.weather_temp), Video.weather_clouds).all()
 
+    # Count distinct visits per food instead of summing max_simultaneous across
+    # joined rows. This avoids inflated values when a visit has multiple linked
+    # detections/videos for the same species.
     food_stats = session.query(
         BirdFood.name,
-        func.sum(SpeciesVisit.max_simultaneous).label('count'),
-    ).join(video_bird_food_association, BirdFood.id == video_bird_food_association.c.birdfood_id).join(
+        func.count(func.distinct(SpeciesVisit.id)).label('count'),
+    ).join(
+        video_bird_food_association, BirdFood.id == video_bird_food_association.c.birdfood_id
+    ).join(
         Video, Video.id == video_bird_food_association.c.video_id
-    ).join(VideoSpecies, VideoSpecies.video_id == Video.id).join(
+    ).join(
+        VideoSpecies, VideoSpecies.video_id == Video.id
+    ).join(
         SpeciesVisit, VideoSpecies.species_visit_id == SpeciesVisit.id
-    ).filter(SpeciesVisit.species_id.in_(all_species_ids)).group_by(
+    ).filter(
+        SpeciesVisit.species_id.in_(all_species_ids)
+    ).group_by(
         BirdFood.name
-    ).order_by(func.sum(SpeciesVisit.max_simultaneous).desc()).limit(5).all()
+    ).order_by(
+        func.count(func.distinct(SpeciesVisit.id)).desc()
+    ).limit(5).all()
 
     recent_visits = session.query(SpeciesVisit).filter(
         SpeciesVisit.species_id.in_(all_species_ids)


### PR DESCRIPTION
## Summary
- remove leftover region-comparison note from Overview (it was already moved to Migration)
- fix species summary food aggregation to count distinct visits per food
- deploy to production and validate smoke tests

## Test plan
- [x] `npm run build` in `app/ui`
- [x] `app/.venv/bin/pytest app/web/tests/test_api.py::TestSpecies -q`
- [x] `BASE_URL=\"https://birdlense.eyera.info\" npm test -- --grep \"Migration page shows region comparison block|Overview page loads\"` in `app/e2e`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Изменения функциональности**
  * Удалена секция сравнения регионов со страницы обзора.
  * Обновлены методы расчета статистики видов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->