### PR TITLE
feat: overview species chart drilldown to timeline

### DIFF
--- a/app/e2e/tests/smoke.spec.ts
+++ b/app/e2e/tests/smoke.spec.ts
@@ -47,6 +47,13 @@ test.describe('Smoke tests', () => {
     });
   });
 
+  test('Overview species chart click opens timeline with species filter', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+    const firstSlice = page.locator('svg path[style*="cursor: pointer"]').first();
+    await firstSlice.click();
+    await expect(page).toHaveURL(/\/timeline\?speciesId=\d+&date=/);
+  });
+
   test('Unknowns legacy URL redirects to timeline review mode', async ({ page }) => {
     await page.goto('/unknowns', { waitUntil: 'networkidle' });
     await expect(page).toHaveURL(/\/timeline\?review=1/);

--- a/app/ui/src/pages/Overview/SpeciesDistributionChart.tsx
+++ b/app/ui/src/pages/Overview/SpeciesDistributionChart.tsx
@@ -5,15 +5,19 @@ import { OverviewTopSpecies } from '../../types';
 import { labelToUniqueHexColor } from '../../util';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import dayjs, { Dayjs } from 'dayjs';
+import { useNavigate } from 'react-router-dom';
 
 interface SpeciesDistributionChartProps {
   data: OverviewTopSpecies[];
+  date?: Dayjs;
 }
 
 export const SpeciesDistributionChart: React.FC<
   SpeciesDistributionChartProps
-> = ({ data }) => {
+> = ({ data, date }) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const pieData = data
     .map((species) => ({
       id: species.id,
@@ -23,6 +27,11 @@ export const SpeciesDistributionChart: React.FC<
     }))
     .filter((item) => item.value > 0)
     .sort((a, b) => b.value - a.value);
+
+  const navigateToTimelineForSpecies = (speciesId: number) => {
+    const dateValue = (date ?? dayjs()).startOf('day').toISOString();
+    navigate(`/timeline?speciesId=${speciesId}&date=${dateValue}`);
+  };
 
   if (pieData.length === 0) {
     return (
@@ -64,6 +73,12 @@ export const SpeciesDistributionChart: React.FC<
         ]}
         width={400}
         height={400}
+        onItemClick={(_, item) => {
+          if (typeof item.dataIndex !== 'number') return;
+          const selected = pieData[item.dataIndex];
+          if (!selected) return;
+          navigateToTimelineForSpecies(Number(selected.id));
+        }}
         slotProps={{
           legend: {
             hidden: true,
@@ -71,6 +86,48 @@ export const SpeciesDistributionChart: React.FC<
         }}
         margin={{ top: 20, bottom: 20, left: 20, right: 20 }}
       />
+      <Box
+        sx={{
+          mt: 1,
+          px: 2,
+          width: '100%',
+          display: 'flex',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          gap: 1.5,
+        }}
+      >
+        {pieData.map((item) => (
+          <Box
+            key={String(item.id)}
+            onClick={() => navigateToTimelineForSpecies(Number(item.id))}
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 1,
+              px: 1.25,
+              py: 0.5,
+              borderRadius: 999,
+              border: 1,
+              borderColor: 'divider',
+              cursor: 'pointer',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+          >
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                borderRadius: '50%',
+                backgroundColor: item.color,
+              }}
+            />
+            <Typography variant="caption">
+              {item.label} ({item.value})
+            </Typography>
+          </Box>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/app/ui/src/pages/Overview/index.tsx
+++ b/app/ui/src/pages/Overview/index.tsx
@@ -323,7 +323,7 @@ export const Overview = () => {
               {t('overview.topSpecies')}
             </Typography>
             {overviewData?.topSpecies && overviewData.topSpecies.length > 0 ? (
-              <SpeciesDistributionChart data={overviewData.topSpecies} />
+              <SpeciesDistributionChart data={overviewData.topSpecies} date={selectedDay} />
             ) : (
               <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
                 {t('overview.noData')}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,7 +99,7 @@ Tracked as separate issues; acceptance criteria live in each issue.
 **Progress update (Mar 2026):**
 - [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — shipped and closed: Unknowns nav removed, `/unknowns` legacy redirect to `/timeline?review=1`, Timeline review mode (chip + counter), OpenAPI + API tests + smoke redirect coverage.
 - [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — shipped and closed: Catalog menu entry removed, legacy `/species` redirects to `/migration-calendar`, species deep links (`/species/:id`) preserved.
-- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — in progress: region comparison block moved from Overview to Migration; Overview now shows a short pointer to Migration.
+- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — shipped and closed: region comparison block moved from Overview to Migration; leftover Overview pointer removed.
 
 | # | Issue | Summary |
 |---|--------|--------|

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -101,7 +101,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 **Прогресс (март 2026):**
 - [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — реализовано и закрыто: убран пункт «Неизвестные», legacy-редирект `/unknowns` → `/timeline?review=1`, режим «На проверке» на Timeline (чип + счётчик), обновлены OpenAPI + API тесты + smoke редиректа.
 - [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — реализовано и закрыто: пункт «Каталог» убран из меню, legacy `/species` редиректит на `/migration-calendar`, deep-link `/species/:id` сохранён.
-- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — в работе: блок «Сравнение с регионом» перенесён с Overview на Migration; на Overview оставлена короткая ссылка-переход.
+- [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — реализовано и закрыто: блок «Сравнение с регионом» перенесён с Overview на Migration; оставшаяся ссылка-переход с Overview удалена.
 
 | # | Issue | Кратко |
 |---|--------|--------|


### PR DESCRIPTION
## Summary
- make Overview top-species pie chart interactive (slice click)
- add clickable species legend chips for the same drilldown path
- route to Timeline with species/date filters and add smoke coverage for the interaction

## Test plan
- [x] `npm run build` in `app/ui`
- [x] `BASE_URL=\"https://birdlense.eyera.info\" npm test -- --grep \"Overview species chart click opens timeline with species filter\"` in `app/e2e`
- [x] `make deploy` and health checks on production

Made with [Cursor](https://cursor.com)