### PR TITLE
fix: wave A bugs #158 #160 #152 (retro-export, retention, UX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Волна A (bugs):** [#158](https://github.com/Gfermoto/BirdLense-Hub/issues/158) ретроэкспорт с периодом подхватывает сирот без `Video`; retention каскадно удаляет `VideoSpecies`/`SpeciesVisit` как при API удалении записи. [#160](https://github.com/Gfermoto/BirdLense-Hub/issues/160) poll regenerate spectrograms/tracks с timeout 120s. [#152](https://github.com/Gfermoto/BirdLense-Hub/issues/152) после удаления видео — возврат по `state.from` или на `/library`.
 - **Dataset export:** при `strict_quality=1` и **ready_for_train** экспорт отменяется, если хотя бы один класс не прошёл `min_images_per_class` (явный отказ вместо тихого пропуска); чекбокс в Library; см. [DATASETS.ru.md](docs/DATASETS.ru.md).
 - **CodeQL / code scanning:** устранены открытые Python-алерты без «принятия риска» — `urlparse` для источников метаданных, линейный разбор скобок вместо ReDoS-регекса, `_safe_image_path_or_none` для Telegram crop, `mkstemp` в спектрограмме, редактирование URL в логах go2RTC; тесты `test_util_metadata.py`; см. [CODEQL.ru.md](docs/CODEQL.ru.md).
 - **Migration UI:** убран дублирующий блок «чеклист за год» над таблицей — те же виды и суммы уже есть в таблице миграции.

--- a/app/ui/src/api/api.tsx
+++ b/app/ui/src/api/api.tsx
@@ -18,6 +18,9 @@ export const BASE_API_URL = `${BASE_URL}/api/ui`;
 
 axios.defaults.timeout = 30000;
 
+/** Длинный timeout для опроса фоновых job (spectrogram / tracks): дефолт 30s рвёт poll на медленном ответе. */
+export const JOB_STATUS_POLL_TIMEOUT_MS = 120_000;
+
 /**
  * Resolve image URL for display.
  * - Absolute (http/https) → as-is

--- a/app/ui/src/components/VisitCard.tsx
+++ b/app/ui/src/components/VisitCard.tsx
@@ -21,7 +21,7 @@ import Share from '@mui/icons-material/Share';
 import Tooltip from '@mui/material/Tooltip';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { downloadDetectionCropForINaturalist } from '../api/api';
@@ -166,6 +166,7 @@ export const VisitCard = memo(function VisitCard({
 }: VisitCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const [expanded, setExpanded] = useState(false);
 
   const startDateTime = new Date(visit.start_time);
@@ -287,7 +288,13 @@ export const VisitCard = memo(function VisitCard({
                       key={`${detection.video_id}-${index}`}
                       detection={detection}
                       speciesName={visit.species.name}
-                      onClick={() => navigate(`/videos/${detection.video_id}`)}
+                      onClick={() =>
+                        navigate(`/videos/${detection.video_id}`, {
+                          state: {
+                            from: `${location.pathname}${location.search}`,
+                          },
+                        })
+                      }
                       isLastInGroup={index === group.length - 1}
                     />
                   ))}

--- a/app/ui/src/pages/Library/RecordingsAndDataset.tsx
+++ b/app/ui/src/pages/Library/RecordingsAndDataset.tsx
@@ -26,6 +26,7 @@ import MergeTypeIcon from '@mui/icons-material/MergeType';
 import BuildIcon from '@mui/icons-material/Build';
 import {
   BASE_API_URL,
+  JOB_STATUS_POLL_TIMEOUT_MS,
   exportDataset,
   retroExportDataset,
   cleanDataset,
@@ -154,7 +155,9 @@ export const RecordingsAndDataset = () => {
         result: RegenerateSpectrogramsResponse | null;
         error: string | null;
         progress?: { processed: number; total: number };
-      }>(`${BASE_API_URL}/system/regenerate-spectrograms/status`);
+      }>(`${BASE_API_URL}/system/regenerate-spectrograms/status`, {
+        timeout: JOB_STATUS_POLL_TIMEOUT_MS,
+      });
       if (data.progress && data.progress.total > 0) {
         setSpectrogramProgress({
           processed: data.progress.processed,
@@ -187,7 +190,9 @@ export const RecordingsAndDataset = () => {
           failed: number;
           skipped: number;
         };
-      }>(`${BASE_API_URL}/system/regenerate-tracks/status`);
+      }>(`${BASE_API_URL}/system/regenerate-tracks/status`, {
+        timeout: JOB_STATUS_POLL_TIMEOUT_MS,
+      });
       if (data.progress && data.progress.total > 0) {
         setTracksProgress({
           processed: data.progress.processed,
@@ -242,7 +247,9 @@ export const RecordingsAndDataset = () => {
   >({
     mutationFn: async (params) => {
       try {
-        await axios.post(`${BASE_API_URL}/system/regenerate-spectrograms`, params || {});
+        await axios.post(`${BASE_API_URL}/system/regenerate-spectrograms`, params || {}, {
+          timeout: JOB_STATUS_POLL_TIMEOUT_MS,
+        });
       } catch (e) {
         // 409 means a batch is already running; attach to its status stream.
         if (!(axios.isAxiosError(e) && e.response?.status === 409)) {
@@ -287,7 +294,9 @@ export const RecordingsAndDataset = () => {
   >({
     mutationFn: async (params) => {
       try {
-        await axios.post(`${BASE_API_URL}/system/regenerate-tracks`, params || {});
+        await axios.post(`${BASE_API_URL}/system/regenerate-tracks`, params || {}, {
+          timeout: JOB_STATUS_POLL_TIMEOUT_MS,
+        });
       } catch (e) {
         // 409 means a batch is already running; attach to in-progress batch.
         if (!(axios.isAxiosError(e) && e.response?.status === 409)) {

--- a/app/ui/src/pages/Unknowns/index.tsx
+++ b/app/ui/src/pages/Unknowns/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -44,12 +44,14 @@ function UnknownCard({
   onCorrect,
   onConfirm,
   canEdit,
+  videoListReturnPath,
 }: {
   detection: UnknownDetection;
   speciesList: { id: number; name: string }[];
   onCorrect: (detectionId: number, speciesId: number) => void;
   onConfirm: (detectionId: number) => void;
   canEdit: boolean;
+  videoListReturnPath: string;
 }) {
   const { t } = useTranslation();
   const [selectedSpeciesId, setSelectedSpeciesId] = useState<number | ''>('');
@@ -125,6 +127,7 @@ function UnknownCard({
           <CardActionArea
             component={Link}
             to={`/videos/${detection.video_id}`}
+            state={{ from: videoListReturnPath }}
             sx={{
               flexShrink: 0,
               borderRadius: 1,
@@ -202,6 +205,8 @@ function UnknownCard({
 export function UnknownsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
+  const videoListReturnPath = `${location.pathname}${location.search}`;
   const queryClient = useQueryClient();
   const { requiresPassword, canEdit, setUnlocked } = useProtectedArea();
   const [showUnlockDialog, setShowUnlockDialog] = useState(false);
@@ -422,6 +427,7 @@ export function UnknownsPage() {
           onCorrect={handleCorrect}
           onConfirm={handleConfirm}
           canEdit={canEdit}
+          videoListReturnPath={videoListReturnPath}
         />
       ))}
       <Snackbar
@@ -445,7 +451,9 @@ export function UnknownsPage() {
               color="inherit"
               size="small"
               onClick={() => {
-                navigate(`/videos/${successVideoId}`);
+                navigate(`/videos/${successVideoId}`, {
+                  state: { from: videoListReturnPath },
+                });
                 clearSuccessSnackbar();
               }}
             >

--- a/app/ui/src/pages/VideoDetails/VideoInfo.tsx
+++ b/app/ui/src/pages/VideoDetails/VideoInfo.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -23,9 +23,20 @@ import { resolveImageUrl, deleteVideo } from '../../api/api';
 import { useProtectedArea } from '../../contexts/ProtectedAreaContext';
 import { BASE_API_URL } from '../../api/api';
 
+function safeInternalPath(from: unknown): string | null {
+  if (typeof from !== 'string' || !from.startsWith('/') || from.startsWith('//')) {
+    return null;
+  }
+  if (from.includes('://') || from.includes('\\')) {
+    return null;
+  }
+  return from;
+}
+
 export const VideoInfo = ({ video }: { video: Video }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { unlocked } = useProtectedArea();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -50,11 +61,13 @@ export const VideoInfo = ({ video }: { video: Video }) => {
         queryClient.invalidateQueries({ queryKey: ['bird-directory'] }),
         queryClient.invalidateQueries({ queryKey: ['speciesSummary'] }),
       ]);
-      // Prefer returning user to previous list context after deletion.
-      if (window.history.length > 1) {
-        navigate(-1);
+      const back = safeInternalPath(
+        (location.state as { from?: string } | null)?.from,
+      );
+      if (back) {
+        navigate(back, { replace: true });
       } else {
-        navigate('/timeline');
+        navigate('/library', { replace: true });
       }
     },
   });

--- a/app/ui/src/pages/VideoDetails/index.tsx
+++ b/app/ui/src/pages/VideoDetails/index.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { fetchVideo, fetchVideoNeighbors } from '../../api/api';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -83,7 +83,9 @@ export const VideoDetails = () => {
                     disabled={!neighbors.previous_id}
                     onClick={() =>
                       neighbors.previous_id &&
-                      navigate(`/videos/${neighbors.previous_id}`)
+                      navigate(`/videos/${neighbors.previous_id}`, {
+                        state: listReturnState,
+                      })
                     }
                   >
                     <NavigateBeforeIcon />
@@ -107,7 +109,9 @@ export const VideoDetails = () => {
                     disabled={!neighbors.next_id}
                     onClick={() =>
                       neighbors.next_id &&
-                      navigate(`/videos/${neighbors.next_id}`)
+                      navigate(`/videos/${neighbors.next_id}`, {
+                        state: listReturnState,
+                      })
                     }
                   >
                     <NavigateNextIcon />

--- a/app/web/services/dataset_export_service.py
+++ b/app/web/services/dataset_export_service.py
@@ -640,6 +640,7 @@ def retro_export_all_video_detections(
     """
     from datetime import datetime, timezone, timedelta
     from models import VideoSpecies, Video
+    from sqlalchemy import and_, or_
     from sqlalchemy.orm import joinedload
 
     saved = 0
@@ -663,10 +664,13 @@ def retro_export_all_video_detections(
     )
     if only_manually_corrected:
         q = q.filter(VideoSpecies.manually_corrected == True)
+    # Период по дате видео; строки без Video (сироты после retention/удаления) тоже
+    # включаем — иначе фильтр по Video.start_time их отсекает и cleanup не срабатывает (#158).
+    date_parts = []
     if start_date:
         try:
             dt_start = datetime.strptime(start_date, '%Y-%m-%d').replace(tzinfo=timezone.utc)
-            q = q.filter(Video.start_time >= dt_start)
+            date_parts.append(Video.start_time >= dt_start)
         except ValueError:
             pass
     if end_date:
@@ -674,9 +678,12 @@ def retro_export_all_video_detections(
             dt_end = datetime.strptime(end_date, '%Y-%m-%d').replace(
                 tzinfo=timezone.utc
             ) + timedelta(days=1)
-            q = q.filter(Video.start_time < dt_end)
+            date_parts.append(Video.start_time < dt_end)
         except ValueError:
             pass
+    if date_parts:
+        in_period = date_parts[0] if len(date_parts) == 1 else and_(*date_parts)
+        q = q.filter(or_(Video.id.is_(None), in_period))
     from services.detection_crop_service import _bbox_for_offset
     q = q.order_by(VideoSpecies.video_id, VideoSpecies.id)
     for vs in q:

--- a/app/web/services/retention_service.py
+++ b/app/web/services/retention_service.py
@@ -7,10 +7,31 @@ import shutil
 from datetime import datetime, timedelta, timezone
 
 from app_config.app_config import app_config
-from models import Video, db
+from models import SpeciesVisit, Video, VideoSpecies, db
 from util import recordings_dir
 
 logger = logging.getLogger(__name__)
+
+
+def _delete_video_row_cascade(video: Video) -> None:
+    """Удалить VideoSpecies и осиротевшие SpeciesVisit, затем Video (как в delete_video API)."""
+    video_id = video.id
+    visit_ids = {vs.species_visit_id for vs in video.video_species if vs.species_visit_id}
+    visits_to_delete = []
+    for vid in visit_ids:
+        other = VideoSpecies.query.filter(
+            VideoSpecies.species_visit_id == vid,
+            VideoSpecies.video_id != video_id,
+        ).first()
+        if not other:
+            visits_to_delete.append(vid)
+    for vs in list(video.video_species):
+        db.session.delete(vs)
+    for vid in visits_to_delete:
+        visit = db.session.get(SpeciesVisit, vid)
+        if visit:
+            db.session.delete(visit)
+    db.session.delete(video)
 
 
 def _get_recordings_size_gb():
@@ -56,7 +77,7 @@ def run_retention():
                                 deleted_size += os.path.getsize(fp)
                         shutil.rmtree(dir_path)
                         deleted_count += 1
-                db.session.delete(video)
+                _delete_video_row_cascade(video)
             except Exception as e:
                 logger.error(f"Retention delete failed for {video.video_path}: {e}")
         try:
@@ -109,7 +130,7 @@ def run_retention():
                             deleted_size += os.path.getsize(fp)
                     shutil.rmtree(dir_path)
                     deleted_count += 1
-                db.session.delete(oldest)
+                _delete_video_row_cascade(oldest)
                 db.session.commit()
             except Exception as e:
                 db.session.rollback()

--- a/app/web/tests/test_dataset_export_service.py
+++ b/app/web/tests/test_dataset_export_service.py
@@ -3,6 +3,8 @@ import io
 import json
 import zipfile
 
+from sqlalchemy import text
+
 from models import db, Species, Video, VideoSpecies
 from services import dataset_export_service as des
 
@@ -27,6 +29,49 @@ class TestDatasetExportOrphans:
             assert result['skipped_orphaned'] >= 1
             assert result['deleted_orphaned'] >= 1
             assert db.session.get(VideoSpecies, orphan_id) is None
+
+    def test_retro_export_deletes_orphan_with_date_filter(self, app):
+        """#158: период не должен отсекать VideoSpecies без строки Video (сироты)."""
+        with app.app_context():
+            sp = Species(name='Orphan Test Bird')
+            db.session.add(sp)
+            db.session.flush()
+            t0 = datetime(2026, 2, 10, 12, 0, 0, tzinfo=timezone.utc)
+            vid = Video(
+                processor_version='t',
+                start_time=t0,
+                end_time=t0,
+                video_path='2026/02/10/120000/x.mp4',
+            )
+            db.session.add(vid)
+            db.session.flush()
+            vs = VideoSpecies(
+                video_id=vid.id,
+                species_id=sp.id,
+                start_time=0.0,
+                end_time=1.0,
+                confidence=0.9,
+                source='video',
+                track_id=1,
+            )
+            db.session.add(vs)
+            db.session.commit()
+            vs_id = vs.id
+            vid_pk = vid.id
+            # Имитация сироты как при отключённых FK в SQLite: строка Video удалена,
+            # VideoSpecies остаётся с несуществующим video_id.
+            db.session.execute(text('DELETE FROM video WHERE id = :i'), {'i': vid_pk})
+            db.session.commit()
+            assert db.session.get(Video, vid_pk) is None
+            assert db.session.get(VideoSpecies, vs_id) is not None
+
+            result = des.retro_export_all_video_detections(
+                min_confidence=0.0,
+                start_date='2026-02-01',
+                end_date='2026-02-28',
+            )
+            assert result['deleted_orphaned'] >= 1
+            assert db.session.get(VideoSpecies, vs_id) is None
 
     def test_clean_dataset_remove_orphaned_keeps_only_valid_tracks(self, app, tmp_path, monkeypatch):
         with app.app_context():

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -217,9 +217,9 @@ bash scripts/github-project-add-backlog-consilium.sh
 3. Для каждой закрытой задачи: PR, комментарий в issue, перевод карточки в Done.
 
 **Волна A (критичные баги, first):**
-- [#158](https://github.com/Gfermoto/BirdLense-Hub/issues/158) — реэкспорт: осиротевшие распознавания без вида/записи.
-- [#160](https://github.com/Gfermoto/BirdLense-Hub/issues/160) — regenerate tracks: прогресс/409/timeout на объёмах.
-- [#152](https://github.com/Gfermoto/BirdLense-Hub/issues/152) — возврат в список после удаления записи.
+- [x] [#158](https://github.com/Gfermoto/BirdLense-Hub/issues/158) — реэкспорт: сироты попадают в выборку при фильтре дат; retention каскадно чистит детекции/визиты; тест `test_retro_export_deletes_orphan_with_date_filter`.
+- [x] [#160](https://github.com/Gfermoto/BirdLense-Hub/issues/160) — poll regenerate spectrograms/tracks: `JOB_STATUS_POLL_TIMEOUT_MS` (120s); 409 → attach к job.
+- [x] [#152](https://github.com/Gfermoto/BirdLense-Hub/issues/152) — после удаления записи: `state.from` или `/library`; `state` с Timeline/Unknowns и при листании соседей.
 
 **Волна B (P2 баги UX-логики):**
 - [x] [#154](https://github.com/Gfermoto/BirdLense-Hub/issues/154) — фильтр по часу из "суточного паттерна".
@@ -234,7 +234,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 - [x] [#162](https://github.com/Gfermoto/BirdLense-Hub/issues/162) — уменьшить пост-скрипты перед обучением.
 
 **Критерий выхода из этапа "мелкие баги/хвосты":**
-- Все issue из волн A+B закрыты.
+- Все issue из волн A+B закрыты (закройте на GitHub #152/#158/#160 после мержа этого коммита).
 - По волне C закрыты минимум 2 задачи с максимальной пользовательской ценностью.
 - `app/web/tests` зелёные, smoke после деплоя зелёный.
 
@@ -248,7 +248,9 @@ bash scripts/github-project-add-backlog-consilium.sh
 
 **Срез 1 ✅:** экспорт Hub — `dataset_info.json` v2 (`manifest` + `quality`), опциональный `test` split, параметр `strict_quality`; см. [DATASETS.ru.md](./DATASETS.ru.md). Влито в `dev`, PR в `main`: [#174](https://github.com/Gfermoto/BirdLense-Hub/pull/174).
 
-**Срез 2:** `strict_quality` дополняется отказом выгрузки, если класс отброшен из‑за `min_images_per_class` (без скрытого «недонабора» ярлыков); чекбокс в Library при «готово к train».
+**Срез 2 ✅:** `strict_quality` дополняется отказом выгрузки, если класс отброшен из‑за `min_images_per_class` (без скрытого «недонабора» ярлыков); чекбокс в Library при «готово к train». PR [#175](https://github.com/Gfermoto/BirdLense-Hub/pull/175).
+
+**Фокус №2 (итог по плану):** train/val/test + манифест v2 + quality/leakage/strict + fingerprint + CI smokes + срез 2 — **закрыто в коде**; дальнейшее — только по новым issues.
 
 
 | Приоритет        | Фокус                                                                                                                   |


### PR DESCRIPTION
## Изменения
- **#158:** `retro_export_all_video_detections` — при фильтре дат сироты без строки `Video` включаются в запрос (`OR Video.id IS NULL` + период по дате для живых видео). Retention удаляет детекции/визиты перед `Video` как в API `delete_video`.
- **#160:** `JOB_STATUS_POLL_TIMEOUT_MS` (120s) на POST старта и GET статуса regenerate spectrograms/tracks в Library.
- **#152:** после удаления записи — `navigate(state.from)` или `/library`; `state.from` проставляется из Timeline (`VisitCard`), Unknowns и при переходе к соседям по дню.

## Тесты
`pytest web/tests` — 90 passed.

Closes #152, closes #158, closes #160

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Исправлена обработка потерянных данных при экспорте с применением фильтра по датам
* Увеличено время ожидания для регенерации спектрограмм и треков до 120 секунд
* Улучшена навигация: после удаления видео система вернёт вас в предыдущее место или в библиотеку
* Исправлена последовательность удаления связанных данных при удалении видео

<!-- end of auto-generated comment: release notes by coderabbit.ai -->