### PR TITLE
docs(roadmap): отметить a11y #117 в v0.2.9

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,7 +84,7 @@ These themes are now tracked as dedicated **Issues** and added to the board; sch
 
 | Theme | Why |
 |-------|-----|
-| **Accessibility (a11y)** | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117): keyboard navigation, focus order, contrast for Unknowns/Video/Migration (follow-up after i18n [#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)). |
+| **Accessibility (a11y)** | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117) ✅ baseline **v0.2.9**: skip link, focus, contrast, axe E2E, [A11Y.md](./A11Y.md); further work via new issues. |
 | **Broader E2E (Playwright)** | [#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118): beyond smoke — login, timeline, critical settings, correction flow. |
 | **Secrets in production** | [#119](https://github.com/Gfermoto/BirdLense-Hub/issues/119) ✅: runbook [SECRETS_ROTATION.md](./SECRETS_ROTATION.md) (complements [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
 | **Stack version sync** | [#120](https://github.com/Gfermoto/BirdLense-Hub/issues/120) ✅: checklist + `python3 scripts/check-docs-version.py` — see [VERSIONING](./VERSIONING.md). |
@@ -99,6 +99,7 @@ Tracked as separate issues; acceptance criteria live in each issue.
 **Preparation before coding ([#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131), [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139)):** [pre-implementation checklist](./PRE_IMPLEMENTATION_UNKNOWN_TIMELINE.md).
 
 **Progress update (Mar 2026):**
+- [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117) — a11y baseline shipped in **v0.2.9** (PR [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187), release [#188](https://github.com/Gfermoto/BirdLense-Hub/pull/188)); see [A11Y.md](./A11Y.md).
 - [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — shipped and closed: Unknowns nav removed, `/unknowns` legacy redirect to `/timeline?review=1`, Timeline review mode (chip + counter), OpenAPI + API tests + smoke redirect coverage.
 - [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — shipped and closed: Catalog menu entry removed, legacy `/species` redirects to `/migration-calendar`, species deep links (`/species/:id`) preserved.
 - [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — shipped and closed: region comparison block moved from Overview to Migration; leftover Overview pointer removed.

--- a/docs/ROADMAP.ru.md
+++ b/docs/ROADMAP.ru.md
@@ -91,7 +91,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 
 | Тема                                       | Зачем                                                                                                                                                                                               |
 | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Доступность (a11y)**                     | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117): клавиатура, фокус, контраст для Unknowns/Video/Migration после i18n ([#52](https://github.com/Gfermoto/BirdLense-Hub/issues/52)).     |
+| **Доступность (a11y)**                     | [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117) ✅ baseline **v0.2.9**: skip link, фокус, контраст, axe E2E, [A11Y.ru.md](./A11Y.ru.md); дальнейшие улучшения — по новым issues.        |
 | **Расширение E2E (Playwright)**            | [#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118): не только смоук — логин, таймлайн, критичные настройки, коррекция видов.                                                              |
 | **Секреты в проде**                        | [#119](https://github.com/Gfermoto/BirdLense-Hub/issues/119) ✅: runbook [SECRETS_ROTATION.ru.md](./SECRETS_ROTATION.ru.md) (дополняет [#47](https://github.com/Gfermoto/BirdLense-Hub/issues/47)). |
 | **Синхронизация версий стека**             | [#120](https://github.com/Gfermoto/BirdLense-Hub/issues/120) ✅: чеклист и `python3 scripts/check-docs-version.py` — см. [VERSIONING.ru.md](./VERSIONING.ru.md).                                                               |
@@ -108,6 +108,7 @@ bash scripts/github-project-add-backlog-consilium.sh
 
 **Прогресс (март 2026):**
 
+- [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117) — baseline a11y и **v0.2.9** (PR [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187), release [#188](https://github.com/Gfermoto/BirdLense-Hub/pull/188)); см. [A11Y.ru.md](./A11Y.ru.md).
 - [#139](https://github.com/Gfermoto/BirdLense-Hub/issues/139) — реализовано и закрыто: убран пункт «Неизвестные», legacy-редирект `/unknowns` → `/timeline?review=1`, режим «На проверке» на Timeline (чип + счётчик), обновлены OpenAPI + API тесты + smoke редиректа.
 - [#131](https://github.com/Gfermoto/BirdLense-Hub/issues/131) — реализовано и закрыто: пункт «Каталог» убран из меню, legacy `/species` редиректит на `/migration-calendar`, deep-link `/species/:id` сохранён.
 - [#127](https://github.com/Gfermoto/BirdLense-Hub/issues/127) — реализовано и закрыто: блок «Сравнение с регионом» перенесён с Overview на Migration; оставшаяся ссылка-переход с Overview удалена.


### PR DESCRIPTION
Обновление таблицы тем и блока прогресса: [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117) baseline в **v0.2.9**, ссылки на A11Y и PR [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187) / [#188](https://github.com/Gfermoto/BirdLense-Hub/pull/188).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Документация

* Отмечено успешное завершение базовой поддержки доступности (a11y) в версии v0.2.9 со следующими выполненными компонентами: skip link для быстрой навигации, фокусировка элементов, контрастность текста и E2E тесты с использованием axe.
* Добавлены актуальные ссылки на специализированную документацию по доступности для получения дополнительной информации.
* Обновлены записи о прогрессе разработки проекта, полностью отражающие завершённую работу по улучшению доступности.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->