### PR TITLE
ci: Deploy workflow hardening + upload-artifact v6

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload Settings UI coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: settings-ui-coverage
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 # Автодеплой при push в main.
-# Требует: self-hosted runner на сервере BirdLense (см. scripts/setup-auto-deploy.sh)
+# Требует: self-hosted runner на сервере BirdLense (см. scripts/setup-auto-deploy.sh).
+# Если workflow «висит» в Queued: runner offline или не зарегистрирован с метками self-hosted + birdlense.
 
 name: Deploy
 
@@ -8,9 +9,17 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: [self-hosted, birdlense]
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
@@ -42,7 +51,12 @@ jobs:
       - name: Verify
         run: |
           sleep 8
-          curl -sf http://127.0.0.1:8085/api/ui/health && echo " OK" || echo " FAIL"
+          if curl -sf http://127.0.0.1:8085/api/ui/health; then
+            echo "Health OK"
+          else
+            echo "::error::Health check failed (curl http://127.0.0.1:8085/api/ui/health)"
+            exit 1
+          fi
 
       - name: Test recognition (optional)
         if: success()

--- a/.github/workflows/e2e-scheduled.yml
+++ b/.github/workflows/e2e-scheduled.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: app/e2e/playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CI / Deploy:** workflow **Deploy** — `concurrency` (один активный деплой на `main`), `timeout-minutes: 45`, `permissions: contents: read`; шаг **Verify** падает с `exit 1`, если health недоступен (раньше только печатался FAIL). **upload-artifact** в CI и E2E → **v6** (Node 24, без предупреждения о Node 20). **INSTALL** / **RU:** пояснение про **Queued** и fallback `make deploy`.
+
 ## [0.2.9] - 2026-03-28
 
 Релиз доступности и регрессионных проверок. Merge: [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187), закрыт [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -73,7 +73,7 @@ Requires: SSH (configure `~/.ssh/config` or `DEPLOY_HOST`), Docker on server, No
 
 **What it does:** stops/removes container `birdlense`, builds UI locally, rsync (excludes `app/data`, `app/app_config/user_config.yaml`, `.tools/` for local CodeQL, venvs, `site/`), merges secrets into `app/.env` on the server, Intel GPU override if `/dev/dri/renderD128` exists, `make build && make start` in `app/` on the server.
 
-**Auto-deploy:** `./scripts/setup-auto-deploy.sh` on server → push to main → auto-deploy (self-hosted runner).
+**Auto-deploy:** `./scripts/setup-auto-deploy.sh` on server → push to main → GitHub Actions workflow **Deploy** (self-hosted runner with labels `self-hosted`, `birdlense`). If the run stays **Queued**, the runner is offline or not registered — use **`make deploy`** from your machine until the runner is fixed.
 
 **Server unavailable:** `cd app && make build` locally; when access returns — `make deploy` (data untouched).
 

--- a/docs/INSTALL.ru.md
+++ b/docs/INSTALL.ru.md
@@ -73,7 +73,7 @@ make deploy
 
 **Что делает:** останавливает и удаляет контейнер `birdlense`, собирает UI локально, rsync (без `app/data`, без `app/app_config/user_config.yaml`, без `.tools/` — локальный CodeQL, без venv и `site/`), дописывает секреты в `app/.env` на сервере, при Intel GPU выставляет override, на сервере в `app/` — `make build && make start`.
 
-**Автодеплой:** `./scripts/setup-auto-deploy.sh` на сервере → push в main → автодеплой (self-hosted runner).
+**Автодеплой:** `./scripts/setup-auto-deploy.sh` на сервере → push в main → workflow **Deploy** в GitHub Actions (self-hosted runner с метками `self-hosted`, `birdlense`). Если запуск долго **Queued** — runner не в сети или не зарегистрирован; до починки используйте **`make deploy`** с вашей машины.
 
 **Сервер недоступен:** `cd app && make build` локально; при появлении доступа — `make deploy` (данные не трогаются).
 


### PR DESCRIPTION
## Что
- **Deploy:** `concurrency` (один деплой), `timeout-minutes: 45`, `permissions: contents: read`; **Verify** — `exit 1`, если health не отвечает.
- **CI / E2E:** `actions/upload-artifact@v6` (убирает предупреждение Node 20).
- **INSTALL / RU:** если Deploy **Queued** — runner offline; до починки `make deploy`.

См. [Unreleased] в CHANGELOG.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Документация**
  * Обновлены инструкции по автоматическому развертыванию с уточнением поведения рабочего потока и рекомендациями по резервному развертыванию.

* **Chores**
  * Оптимизированы рабочие потоки CI/CD: добавлена очередность развертываний, ограничена область доступа и установлено время ожидания.
  * Улучшена обработка ошибок при проверке здоровья развертывания.
  * Обновлены инструменты загрузки артефактов в рабочих потоках.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->