### PR TITLE
chore: Dependabot fixes (npm, requests), setup-auto-deploy latest runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **CI / Deploy:** workflow **Deploy** — `concurrency` (один активный деплой на `main`), `timeout-minutes: 45`, `permissions: contents: read`; шаг **Verify** падает с `exit 1`, если health недоступен (раньше только печатался FAIL). **upload-artifact** в CI и E2E → **v6** (Node 24, без предупреждения о Node 20). **INSTALL** / **RU:** пояснение про **Queued** и fallback `make deploy`.
 
+- **Зависимости / безопасность:** `app/ui` — `npm audit fix` (транзитивные обновления, в т.ч. brace-expansion, picomatch, yaml, цепочка до `serialize-javascript`); `requests` **2.33.0** в `app/web/requirements.txt` и `app/processor/requirements.txt`. **scripts/setup-auto-deploy.sh** — скачивание runner по **последнему** релизу с GitHub API, `RUNNER_ALLOW_RUNASROOT=1` под root, `./config.sh` с `--unattended --replace`.
+
 ## [0.2.9] - 2026-03-28
 
 Релиз доступности и регрессионных проверок. Merge: [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187), закрыт [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117).

--- a/app/processor/requirements.txt
+++ b/app/processor/requirements.txt
@@ -2,7 +2,7 @@
 ultralytics==8.4.21
 pyyaml==6.0.3
 paho-mqtt==2.1.0
-requests==2.32.4
+requests==2.33.0
 ncnn==1.0.20240410
 
 # numpy 2.x — совместим с opencv, librosa, ultralytics

--- a/app/ui/package-lock.json
+++ b/app/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-react-typescript-starter",
-  "version": "0.2.3",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-react-typescript-starter",
-      "version": "0.2.3",
+      "version": "0.2.9",
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
@@ -48,6 +48,10 @@
         "vite-plugin-pwa": "^1.2.0",
         "workbox-core": "^7.4.0",
         "workbox-precaching": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=22.13.0 <23",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3108,7 +3112,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3526,7 +3532,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3748,7 +3756,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -5066,7 +5076,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5347,7 +5359,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6587,7 +6601,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7395,7 +7411,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -7957,9 +7975,9 @@
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8602,7 +8620,9 @@
       "license": "MIT"
     },
     "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8765,7 +8785,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/app/web/requirements.txt
+++ b/app/web/requirements.txt
@@ -7,7 +7,7 @@ coverage[toml]>=7.0.0
 paho-mqtt==2.1.0
 Flask_SQLAlchemy==3.1.1
 Flask-Cors>=6.0.0
-requests==2.32.4
+requests==2.33.0
 gunicorn==23.0.0
 psutil==5.9.8
 httpx>=0.28.0

--- a/scripts/setup-auto-deploy.sh
+++ b/scripts/setup-auto-deploy.sh
@@ -39,7 +39,13 @@ if [ ! -f "$RUNNER_DIR/run.sh" ]; then
   echo "2. Установка GitHub Actions runner..."
   mkdir -p "$RUNNER_DIR"
   cd "$RUNNER_DIR"
-  curl -sL https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz | tar xz
+  RUNNER_VER="$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')"
+  if [ -z "$RUNNER_VER" ]; then
+    echo "   Ошибка: не удалось получить версию runner с GitHub API." >&2
+    exit 1
+  fi
+  echo "   Версия: $RUNNER_VER"
+  curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VER}/actions-runner-linux-x64-${RUNNER_VER}.tar.gz" | tar xz
   echo "   Скачано."
 else
   echo "2. Runner уже установлен"
@@ -54,7 +60,8 @@ read -p "Введи токен (или Enter чтобы пропустить): "
 
 if [ -n "$TOKEN" ]; then
   cd "$RUNNER_DIR"
-  ./config.sh --url "https://github.com/${REPO}" --token "$TOKEN" --labels birdlense --work _work
+  [ "$(id -u)" = 0 ] && export RUNNER_ALLOW_RUNASROOT=1
+  ./config.sh --url "https://github.com/${REPO}" --token "$TOKEN" --labels birdlense --work _work --unattended --replace
   ./svc.sh install
   ./svc.sh start
   echo "   Runner установлен как сервис."


### PR DESCRIPTION
## Summary
- **UI:** `npm audit fix` in `app/ui` (package-lock) — закрывает moderate/high по транзитивам (brace-expansion, picomatch, yaml, serialize-javascript).
- **Python:** `requests==2.33.0` в `app/web/requirements.txt` и `app/processor/requirements.txt`.
- **scripts/setup-auto-deploy.sh:** скачивание последнего `actions/runner` с GitHub API; под root — `RUNNER_ALLOW_RUNASROOT`; `config.sh --unattended --replace`.
- **CHANGELOG** [Unreleased].

## Deploy
Self-hosted runner на хабе зарегистрирован и **online** (метки `self-hosted`, `birdlense`). После merge в `main` workflow **Deploy** должен уйти с очереди.

Проверено локально: `npm run build` (app/ui), `make test-web` (app) — 100 passed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Исправления ошибок**
  * Обновлены зависимости безопасности, включая `requests` до версии 2.33.0 в приложениях web и processor.
  * Выполнена проверка безопасности зависимостей.

* **Улучшения**
  * Обновлен скрипт развертывания для автоматического использования последней версии GitHub Actions Runner.
  * Добавлена поддержка развертывания с правами администратора.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->