### PR TITLE
ci(deploy): resilient Verify (retries, BIRDLENSE_PORT)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,13 +50,31 @@ jobs:
 
       - name: Verify
         run: |
-          sleep 8
-          if curl -sf http://127.0.0.1:8085/api/ui/health; then
-            echo "Health OK"
-          else
-            echo "::error::Health check failed (curl http://127.0.0.1:8085/api/ui/health)"
-            exit 1
+          set -euo pipefail
+          DEPLOY_DIR="${DEPLOY_DIR:-/root/BirdLense}"
+          ENV_FILE="$DEPLOY_DIR/app/.env"
+          PORT=8085
+          if [ -f "$ENV_FILE" ]; then
+            V=$(grep -E '^[[:space:]]*BIRDLENSE_PORT=' "$ENV_FILE" | tail -1 || true)
+            if [ -n "$V" ]; then
+              PORT="${V#*=}"
+              PORT="${PORT//\"/}"
+              PORT="${PORT//\'/}"
+            fi
           fi
+          URL="http://127.0.0.1:${PORT}/api/ui/health"
+          echo "Health check: $URL"
+          sleep 10
+          for i in $(seq 1 36); do
+            if curl -sf "$URL"; then
+              echo "Health OK (attempt $i)"
+              exit 0
+            fi
+            echo "Health not ready, attempt $i/36 …"
+            sleep 5
+          done
+          echo "::error::Health check failed after retries ($URL)"
+          exit 1
 
       - name: Test recognition (optional)
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Зависимости / безопасность:** `app/ui` — `npm audit fix` (транзитивные обновления, в т.ч. brace-expansion, picomatch, yaml, цепочка до `serialize-javascript`); `requests` **2.33.0** в `app/web/requirements.txt` и `app/processor/requirements.txt`. **scripts/setup-auto-deploy.sh** — скачивание runner по **последнему** релизу с GitHub API, `RUNNER_ALLOW_RUNASROOT=1` под root, `./config.sh` с `--unattended --replace`.
 
+- **CI / Deploy:** шаг **Verify** — порт из `BIRDLENSE_PORT` в `app/.env` на сервере (иначе 8085), пауза 10 с и до **36** попыток `curl` с интервалом 5 с после `make pull` (старт контейнера и приложения).
+
 ## [0.2.9] - 2026-03-28
 
 Релиз доступности и регрессионных проверок. Merge: [#187](https://github.com/Gfermoto/BirdLense-Hub/pull/187), закрыт [#117](https://github.com/Gfermoto/BirdLense-Hub/issues/117).


### PR DESCRIPTION
Fixes flaky Deploy **Verify** after `make pull`: read `BIRDLENSE_PORT` from server `app/.env`, initial 10s wait, up to 36×5s retries on health curl.

Follow-up to green runner + #191 where Verify failed while service became healthy shortly after.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Chores**
  * Улучшена логика проверки здоровья при развертывании с использованием механизма повторных попыток и динамической конфигурации портов для повышения надежности запуска приложения.

* **Documentation**
  * Обновлена документация о процессе верификации развертывания с описанием нового поведения проверок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->