### PR TITLE
test(e2e): Migration year filters (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **E2E ([#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118)):** `app/e2e/tests/migration.spec.ts` — фильтр года на Migration и сброс на «все годы»; [TESTING.md](docs/TESTING.md) / [RU](docs/TESTING.ru.md) — отладка отдельного файла (`playwright test` / `--debug`).
+
 ### Changed
 
 - **CI / Deploy:** workflow **Deploy** — `concurrency` (один активный деплой на `main`), `timeout-minutes: 45`, `permissions: contents: read`; шаг **Verify** падает с `exit 1`, если health недоступен (раньше только печатался FAIL). **upload-artifact** в CI и E2E → **v6** (Node 24, без предупреждения о Node 20). **INSTALL** / **RU:** пояснение про **Queued** и fallback `make deploy`.

--- a/app/e2e/tests/migration.spec.ts
+++ b/app/e2e/tests/migration.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Critical operator paths for Migration (issue #118).
+ * Filters render only when the calendar has species rows (non-empty DB).
+ */
+test.describe('Migration calendar', () => {
+  test.describe.configure({ timeout: 45_000 });
+
+  test('From year filter refetches table without error', async ({ page }) => {
+    await page.goto('/migration-calendar', { waitUntil: 'networkidle' });
+    const fromYear = page.getByLabel(/From year|С года/i);
+    if (!(await fromYear.isVisible().catch(() => false))) {
+      test.skip(true, 'No migration table (empty species) — filters not rendered');
+    }
+    const targetYear = new Date().getFullYear() - 1;
+    await fromYear.click();
+    await page.getByRole('option', { name: String(targetYear) }).click();
+    await expect(page.getByText(/Error loading migration calendar|Ошибка загрузки/i)).toHaveCount(0);
+    await expect(page.getByRole('table')).toBeVisible({ timeout: 25_000 });
+    await expect(page.getByRole('columnheader', { name: 'Σ' })).toBeVisible();
+  });
+
+  test('From year can be reset to All years', async ({ page }) => {
+    await page.goto('/migration-calendar', { waitUntil: 'networkidle' });
+    const fromYear = page.getByLabel(/From year|С года/i);
+    if (!(await fromYear.isVisible().catch(() => false))) {
+      test.skip(true, 'No migration table (empty species) — filters not rendered');
+    }
+    const targetYear = new Date().getFullYear() - 2;
+    await fromYear.click();
+    await page.getByRole('option', { name: String(targetYear) }).click();
+    await expect(page.getByRole('table')).toBeVisible({ timeout: 25_000 });
+
+    await fromYear.click();
+    await page.getByRole('option', { name: /All years|Все годы/i }).click();
+    await expect(page.getByRole('table')).toBeVisible({ timeout: 25_000 });
+    await expect(page.getByText(/Error loading migration calendar|Ошибка загрузки/i)).toHaveCount(0);
+  });
+});

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -58,9 +58,11 @@ E2E runs against a **live** instance (UI + API).
 3. Remote: `cd app && BASE_URL=http://YOUR_HOST:8085 make test-e2e`
 4. **Settings password:** set `E2E_SETTINGS_PASSWORD=...` for a full run. Without it, Settings tests and `GET /api/ui/settings` are **skipped**.
 
-**Suites:** `smoke.spec.ts` (home, nav, Settings, Live), `api.spec.ts` (health, status, settings, cameras, weather, feed dispense), `settings.spec.ts` (form, Video/MQTT/Feed sections).
+**Suites:** `smoke.spec.ts` (home, nav, Settings, Live), `api.spec.ts` (health, status, settings, cameras, weather, feed dispense), `settings.spec.ts` (form, Video/MQTT/Feed sections), `migration.spec.ts` (Migration **From year** filter + reset to **All years**; **skipped** if the calendar has no species table / empty DB).
 
 API-only (no browser): `cd app/e2e && npm test -- --grep @api`
+
+Debug one file / UI mode: `cd app/e2e && npx playwright test tests/migration.spec.ts` or `npx playwright test --debug tests/migration.spec.ts`.
 
 **Scheduled CI:** workflow **E2E (Playwright)** (`.github/workflows/e2e-scheduled.yml`) runs **weekly** and on **workflow_dispatch** — not a required check; use it to catch regressions without running Playwright on every PR.
 

--- a/docs/TESTING.ru.md
+++ b/docs/TESTING.ru.md
@@ -115,11 +115,19 @@ E2E проверяют UI и API на работающем экземпляре.
 - **smoke.spec.ts**: загрузка главной, навигация, Settings, Live
 - **api.spec.ts**: `/api/ui/health`, `/api/ui/status`, `/api/ui/settings`, `/api/ui/cameras`, `/api/ui/weather`, `/api/ui/feed/dispense`
 - **settings.spec.ts**: форма настроек, секции Video/MQTT, Feed
+- **migration.spec.ts**: фильтр «С года» / From year на странице Migration (и сброс на «Все годы»); при пустой БД без таблицы миграции тесты помечаются **skip**
 
 **Только API-тесты (без браузера):**
 
 ```bash
 cd app/e2e && npm test -- --grep @api
+```
+
+**Отладка одного файла / UI mode:**
+
+```bash
+cd app/e2e && npx playwright test tests/migration.spec.ts
+cd app/e2e && npx playwright test --debug tests/migration.spec.ts
 ```
 
 **CI по расписанию:** workflow **E2E (Playwright)** (`.github/workflows/e2e-scheduled.yml`) — **раз в неделю** и по **workflow_dispatch**; в ruleset **не required** — для отлова регрессий без Playwright на каждом PR.


### PR DESCRIPTION
## Summary
Cherry-pick of merged **dev** work: E2E **Migration** filters ([\#118](https://github.com/Gfermoto/BirdLense-Hub/issues/118)).

- `app/e2e/tests/migration.spec.ts`
- `docs/TESTING.md`, `docs/TESTING.ru.md`, `CHANGELOG` [Unreleased]

Merged to **dev** via PR [#194](https://github.com/Gfermoto/BirdLense-Hub/pull/194).

## Note
E2E file is exercised by weekly `e2e-scheduled`, not required on PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Тесты**
  * Добавлены E2E тесты для календаря миграций, включая проверку фильтра "С года" и его сброса на "Все годы", а также валидацию загрузки данных без ошибок.

* **Документация**
  * Обновлена документация по тестированию с описанием нового E2E набора тестов и инструкциями по отладке отдельных Playwright спецификаций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->