### PR TITLE
security(ui): Dependabot — lodash 4.18+, serialize-javascript override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **UI (`app/ui`):** refreshed `package-lock.json` and `overrides` so **lodash** resolves to **≥4.18.0** (addresses [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc), [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh)); **serialize-javascript** pinned via override to **≥7.0.5**. `npm audit` clean. Python `requests` / **Flask-Cors** were already at patched versions in `app/web` and `app/processor` requirements.
+
 ### Changed
 
 - **Docs / repo hygiene:** added [REPOSITORY_LAYOUT](docs/REPOSITORY_LAYOUT.md) (EN/RU) for onboarding; moved publication drafts to `docs/article/`; refreshed docs index version line and roadmap stack (Ultralytics pip vs Docker base). Root `.gitignore` now ignores `/.pytest_cache/`.

--- a/app/ui/package-lock.json
+++ b/app/ui/package-lock.json
@@ -6213,7 +6213,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -61,6 +61,7 @@
     "npm": "10.9.2"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "lodash": ">=4.18.0",
+    "serialize-javascript": ">=7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- `npm audit fix` in `app/ui`: **lodash** 4.17.23 → **4.18.1** (GHSA-r5fr-rjxr-66jc, GHSA-f23m-r3pf-42rh).
- `package.json` **overrides**: `lodash >=4.18.0`, `serialize-javascript >=7.0.5` (aligns with prior PWA/workbox chain).
- `npm audit`: 0 vulnerabilities locally.

## Python
`app/web/requirements.txt` and `app/processor/requirements.txt` already pin **requests==2.33.0** and **Flask-Cors>=6.0.0** (patched per Dependabot ranges). No file change.

## After merge
GitHub will rescan `main`; remaining Dependabot rows should clear once default branch includes this lockfile.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления безопасности

* Обновлены ограничения зависимостей в приложении: повышена версия `serialize-javascript` до ≥7.0.5 и добавлено ограничение для `lodash` ≥4.18.0
* Проверка безопасности `npm audit` прошла успешно (чистый результат)
* Python-зависимости компонентов web и processor уже находятся на защищённых версиях

<!-- end of auto-generated comment: release notes by coderabbit.ai -->