### PR TITLE
fix(ci,security): пин весов HF, CodeQL, nitpicks после 0.3.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-refactor-backend-monolith.md
+++ b/.github/ISSUE_TEMPLATE/01-refactor-backend-monolith.md
@@ -12,6 +12,12 @@ The file `app/web/routes/ui_system_routes.py` contains ~96,000 lines of code, vi
 - [ ] Split routes into domain-specific files.
 - [ ] Introduce Pydantic schemas for validation.
 
+## Definition of Done
+- [ ] Крупные доменные куски вынесены из `ui_system_routes.py` в отдельные модули в `routes/` (или эквивалент по согласованной схеме).
+- [ ] Повторно используемая логика живёт в `services/` без прямой зависимости от Flask `request` в ядре.
+- [ ] Для mutating API есть явные схемы валидации (`schemas/` или Pydantic) и согласованные ответы об ошибках.
+- [ ] CI зелёный; при изменении контрактов — обновлён OpenAPI/контрактные тесты.
+
 ## Proposed Structure
 app/web/
 ├── routes/ (split by domain)

--- a/.github/ISSUE_TEMPLATE/03-migrate-to-poetry.md
+++ b/.github/ISSUE_TEMPLATE/03-migrate-to-poetry.md
@@ -5,9 +5,17 @@ labels: ["chore", "dependencies"]
 ---
 
 ## Problem
-Using `requirements.txt` leads to dependency hell.
+Using `requirements.txt` complicates reproducible installs and environment splits:
+- No lock file for identical CI vs developer installs
+- Harder to separate web / processor / dev dependencies cleanly
+- Version bumps often surface conflicts and transitive dependency surprises
 
 ## Goals
 - [ ] Initialize `pyproject.toml` at root.
 - [ ] Define dependency groups (web, processor, dev).
+- [ ] Configure Poetry (virtualenvs, cache) and migrate version pins from current requirements.
+- [ ] Generate and commit `poetry.lock`.
+- [ ] Update GitHub Actions to use `poetry install` (or equivalent).
+- [ ] Verify clean install and full CI test run.
+- [ ] Update README/CONTRIBUTING for developers.
 - [ ] Remove all `requirements.txt` files.

--- a/.github/ISSUE_TEMPLATE/04-refactor-processor-architecture.md
+++ b/.github/ISSUE_TEMPLATE/04-refactor-processor-architecture.md
@@ -10,3 +10,8 @@ Modules like `detection_strategy.py` mix domain logic with infrastructure.
 ## Goals
 - [ ] Separate Domain, Application, Infrastructure layers.
 - [ ] Define interfaces for repositories.
+
+## Definition of Done
+- [ ] Направление зависимостей: Infrastructure → Application → Domain (без обратных импортов домена в инфраструктуру).
+- [ ] Unit-тесты Domain/Application проходят без реальной ФС/сети (инфраструктура заменена заглушками).
+- [ ] В `docs/` или в issue зафиксированы заметки по миграции для затронутых модулей.

--- a/.github/ISSUE_TEMPLATE/05-frontend-fsd-refactor.md
+++ b/.github/ISSUE_TEMPLATE/05-frontend-fsd-refactor.md
@@ -10,3 +10,8 @@ Flat structure and massive `api.tsx` (34k lines).
 ## Goals
 - [ ] Split src/ into app, pages, widgets, features, entities, shared.
 - [ ] Move API logic to shared/api.
+
+## Definition of Done
+- [ ] В репозитории видно целевое дерево FSD (каталоги `app/`, `pages/`, `widgets/`, `features/`, `entities/`, `shared/` — или согласованный вариант).
+- [ ] Монолитный `api.tsx` декомпозирован: клиенты API лежат в `shared/api` (или `shared/api/*`) по доменным модулям.
+- [ ] `npm run build` и линтер в CI проходят; нет регрессии по основным пользовательским сценариям (smoke/E2E по наличию).

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -172,7 +172,16 @@ jobs:
 
       - name: Processor .pt weights for integration tests
         working-directory: ${{ github.workspace }}
-        run: ./scripts/fetch-processor-weights.sh
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if ./scripts/fetch-processor-weights.sh; then
+              exit 0
+            fi
+            sleep $((attempt * 10))
+          done
+          echo "Failed to fetch processor weights after retries" >&2
+          exit 1
 
       - name: Build birdlense image
         run: docker compose build birdlense

--- a/CHECKSUMS
+++ b/CHECKSUMS
@@ -1,1 +1,2 @@
 0ebbc80d4a7680d14987a577cd21342b65ecfd94632bd9a8da63ae6417644ee1  app/yolo11n.pt
+d9a52384f7e55c5deb5f33178f0e265518d62b60e3bbea752c8a44b6192aa13b  app/processor/models/classification/weights/best.pt

--- a/CHECKSUMS
+++ b/CHECKSUMS
@@ -1,2 +1,2 @@
 0ebbc80d4a7680d14987a577cd21342b65ecfd94632bd9a8da63ae6417644ee1  app/yolo11n.pt
-d9a52384f7e55c5deb5f33178f0e265518d62b60e3bbea752c8a44b6192aa13b  app/processor/models/classification/weights/best.pt
+9e99b6d1b0b7697f671a728bfa887f2f45d574ec932e8a745855e9818aadd46e  app/processor/models/classification/weights/best.pt

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -50,6 +50,8 @@ COPY web/ ./web/
 COPY processor/ ./processor/
 COPY app_config/ ./app_config/
 COPY scripts/ ./scripts/
+# SHA256 классификатора — синхронизировать с CHECKSUMS (app/processor/.../best.pt) и fetch-processor-weights.sh.
+ARG CLASSIFIER_SHA256=d9a52384f7e55c5deb5f33178f0e265518d62b60e3bbea752c8a44b6192aa13b
 # two_stage: .pt не в git; бинарный детектор должен быть предоставлен в контексте сборки,
 # EU-классификатор скачивается с Hugging Face. Если свои веса уже лежат в контексте, пропускаем скачивание.
 RUN mkdir -p processor/models/detection/weights processor/models/classification/weights \
@@ -58,8 +60,11 @@ RUN mkdir -p processor/models/detection/weights processor/models/classification/
            -d processor/models/detection/weights/; \
        fi \
     && if [ ! -s processor/models/classification/weights/best.pt ]; then \
-         curl -fsSL -o processor/models/classification/weights/best.pt \
-           "https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/main/best.pt"; \
+         curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 \
+           -o processor/models/classification/weights/best.pt.tmp \
+           "https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/main/best.pt" \
+         && echo "${CLASSIFIER_SHA256}  processor/models/classification/weights/best.pt.tmp" | sha256sum -c - \
+         && mv processor/models/classification/weights/best.pt.tmp processor/models/classification/weights/best.pt; \
        fi
 RUN pip install --no-cache-dir -r web/requirements.txt \
     && pip install --no-cache-dir -r processor/requirements.txt

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -51,7 +51,7 @@ COPY processor/ ./processor/
 COPY app_config/ ./app_config/
 COPY scripts/ ./scripts/
 # SHA256 классификатора — синхронизировать с CHECKSUMS (app/processor/.../best.pt) и fetch-processor-weights.sh.
-ARG CLASSIFIER_SHA256=d9a52384f7e55c5deb5f33178f0e265518d62b60e3bbea752c8a44b6192aa13b
+ARG CLASSIFIER_SHA256=9e99b6d1b0b7697f671a728bfa887f2f45d574ec932e8a745855e9818aadd46e
 # two_stage: .pt не в git; бинарный детектор должен быть предоставлен в контексте сборки,
 # EU-классификатор скачивается с Hugging Face. Если свои веса уже лежат в контексте, пропускаем скачивание.
 RUN mkdir -p processor/models/detection/weights processor/models/classification/weights \
@@ -62,7 +62,7 @@ RUN mkdir -p processor/models/detection/weights processor/models/classification/
     && if [ ! -s processor/models/classification/weights/best.pt ]; then \
          curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 \
            -o processor/models/classification/weights/best.pt.tmp \
-           "https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/main/best.pt" \
+           "https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/c6af5aa595cbb1198a61bcf2f3f9c2adc3772dc9/best.pt" \
          && echo "${CLASSIFIER_SHA256}  processor/models/classification/weights/best.pt.tmp" | sha256sum -c - \
          && mv processor/models/classification/weights/best.pt.tmp processor/models/classification/weights/best.pt; \
        fi

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,10 @@
-.PHONY: build start stop logs deploy pull setup test test-web test-web-local venv-web test-e2e test-coverage test-report local local-build docs docs-python docs-ui docs-check
+.PHONY: all clean build start stop logs deploy pull setup test test-web test-web-local venv-web test-e2e test-coverage test-report local local-build docs docs-python docs-ui docs-check
+
+all: build
+
+clean:
+	@docker compose down --remove-orphans 2>/dev/null || true
+	@rm -rf htmlcov .coverage
 
 # Локальный venv для pytest без Docker (тот же requirements, что в CI openapi job).
 VENV ?= .venv
@@ -61,9 +67,11 @@ test-web:
 
 # Один раз: python3 -m venv .venv && pip install -r web/requirements.txt
 venv-web:
-	@if [ ! -x "$(VENV)/bin/python" ]; then python3 -m venv "$(VENV)"; fi
-	@"$(VENV)/bin/python" -m pip install -U pip
-	env PIP_NO_USER=1 "$(VENV)/bin/python" -m pip install -r web/requirements.txt
+	@if [ ! -x "$(VENV)/bin/python" ]; then \
+		python3 -m venv "$(VENV)" && \
+		"$(VENV)/bin/python" -m pip install -U pip; \
+	fi
+	env PIP_NO_USER=1 "$(VENV)/bin/python" -m pip install -U -r web/requirements.txt
 	@echo "venv-web: готово $(abspath $(VENV)) (используйте: make test-web-local)"
 
 # Pytest на хосте (без sqlalchemy в системном python тесты падают — используйте этот таргет или Docker test-web).

--- a/app/README.ru.md
+++ b/app/README.ru.md
@@ -50,7 +50,7 @@ UI: http://localhost:8085
 ## Конфигурация
 
 - `app_config/default_config.yaml` — значения по умолчанию из образа/репозитория (базовая линия).
-- `app_config/user_config.yaml` — **переоператорские настройки**: глубокий merge поверх default; основной файл для сохранения настроек из UI. При деплое на сервер не перезаписываются живые `data/` и `user_config.yaml` (см. `docs/INSTALL.md` и правила deploy в репозитории).
+- `app_config/user_config.yaml` — **пользовательские настройки** (глубокий merge поверх default); основной файл для сохранения настроек из UI. При деплое на сервер не перезаписываются живые `data/` и `user_config.yaml` (см. `docs/INSTALL.md` и правила deploy в репозитории).
 - **Переменные окружения** — слой рантайма для секретов и инфраструктуры: `DATA_DIR`, `MQTT_BROKER`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `GO2RTC_URL`, `PROCESSOR_SECRET`, `FLASK_SECRET_KEY`, `BIRDLENSE_*`, `MCP_TOKEN` и др. Во многих местах порядок **сначала env, потом YAML** (например брокер MQTT в bootstrap процессора и части UI).
 - При загрузке выполняется проверка **типов верхнеуровневых секций** merged-конфига (известные секции должны быть mapping, не скаляр). Ошибки пишутся в лог; `BIRDLENSE_STRICT_CONFIG=1` — **падать при старте**, если валидация не прошла.
 

--- a/app/app_config/app_config.py
+++ b/app/app_config/app_config.py
@@ -211,6 +211,7 @@ class AppConfig:
             )
             return False
         changed = False
+        adjusted: list[str] = []
         for path, floor in CONFIDENCE_FLOORS.items():
             current = cls._get_nested(config, path)
             if current is None:
@@ -219,10 +220,11 @@ class AppConfig:
             if coerced < floor:
                 cls._set_nested(config, path, floor)
                 changed = True
+                adjusted.append(f'{path}: {current!r} -> {floor}')
         if changed:
             logger.warning(
                 'Clamped legacy low confidence settings to safe floors: %s',
-                ', '.join(f'{key}>={value}' for key, value in CONFIDENCE_FLOORS.items()),
+                '; '.join(adjusted),
             )
         return changed
 

--- a/app/app_config/default_config.yaml
+++ b/app/app_config/default_config.yaml
@@ -17,7 +17,8 @@ general:
   donate_url: ""
 
 # Video/Audio processor settings
-# Важно: значения в user_config.yaml (секция processor / detection) полностью перекрывают дефолты ниже.
+# Важно: user_config.yaml мержится с дефолтами рекурсивно (merge_dicts): заданные ключи
+# переопределяют вложенные значения на всех уровнях; отсутствующие ключи берутся из default.
 processor:
   tracker: "bytetrack.yaml"
   max_record_seconds: 60
@@ -132,8 +133,8 @@ processor:
     - "Pigeons and Doves"
     - "Woodpeckers"
   save_images: false
-  # Сохранять best_frame в data/dataset/train/<Species>/ для экспорта и дообучения
-  save_dataset_crops: true
+  # Сохранять best_frame в data/dataset/train/<Species>/ для экспорта и дообучения (по умолчанию выкл. — не раздувать диск)
+  save_dataset_crops: false
   dataset_min_confidence: 0.58
   # video.source=file: оставить папку сессии с записанным mp4 при 0 детекций (без create_video / кропов из пайплайна)
   keep_recording_when_no_detections: false

--- a/app/web/routes/processor_routes.py
+++ b/app/web/routes/processor_routes.py
@@ -31,6 +31,10 @@ def _run_gallery_upload_thread(flask_app, video_id: int):
 
 # Path traversal protection: video_path must match data/recordings/YYYY/MM/DD/timestamp/video.mp4
 VIDEO_PATH_RE = re.compile(r'^data/recordings/\d{4}/\d{2}/\d{2}/[\d\-:]+/video\.mp4$')
+# Spectrogram alongside recording (same directory layout as processor-generated files).
+SPECTROGRAM_PATH_RE = re.compile(
+    r'^data/recordings/\d{4}/\d{2}/\d{2}/[\d\-:]+/spectrogram_\d+\.jpg$'
+)
 
 
 def _log_activity(type_name: str, payload: dict) -> None:
@@ -68,12 +72,17 @@ def _processor_detection_payload(raw: dict) -> dict:
 
 
 def _validate_recording_file_exists(*, logical_path: str) -> tuple[bool, str | None, str | None]:
+    """Caller must pass only paths that matched VIDEO_PATH_RE; we re-check for defense in depth."""
+    if not VIDEO_PATH_RE.match(logical_path):
+        return False, None, 'video_path_invalid'
     full = full_path_for_video(logical_path)
     if not full:
         return False, None, 'video_path_unresolvable'
     try:
+        # codeql[py/path-injection]: full from full_path_for_video under DATA_DIR after VIDEO_PATH_RE
         if not os.path.isfile(full):
             return False, full, 'video_file_missing'
+        # codeql[py/path-injection]: full from full_path_for_video under DATA_DIR after VIDEO_PATH_RE
         if os.path.getsize(full) <= 0:
             return False, full, 'video_file_unreadable'
     except OSError:
@@ -204,12 +213,16 @@ def register_routes(app):
 
         spec_path = (data.get('spectrogram_path') or '').strip()
         if spec_path:
-            spec_full = full_path_for_video(spec_path)
-            try:
-                if not spec_full or not os.path.isfile(spec_full):
-                    data['spectrogram_path'] = ''
-            except OSError:
+            if not SPECTROGRAM_PATH_RE.match(spec_path):
                 data['spectrogram_path'] = ''
+            else:
+                spec_full = full_path_for_video(spec_path)
+                try:
+                    # codeql[py/path-injection]: spec_full via full_path_for_video after SPECTROGRAM_PATH_RE
+                    if not spec_full or not os.path.isfile(spec_full):
+                        data['spectrogram_path'] = ''
+                except OSError:
+                    data['spectrogram_path'] = ''
 
         try:
             video = Video(

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -352,7 +352,7 @@ For a **dedicated topic family** (weight + bird presence + optional command), se
 | `notifications.paid_media_forward_star_count` | Free view: 0=allow forward, >0=block. Paid: forward allowed. |
 | `general.notification_excluded_species` | Excluded species |
 | `processor.save_images` | If true — save detection frames to disk for debugging. It does not control Telegram photo delivery |
-| `processor.save_dataset_crops` | If true — save `best_frame` to `data/dataset/train/<Species>/` |
+| `processor.save_dataset_crops` | Default **false** (opt-in). If true — save `best_frame` to `data/dataset/train/<Species>/` |
 | `processor.dataset_min_confidence` | Min confidence (0.0–1.0) for dataset crop. Default 0.5 |
 
 **How BirdLense sends Telegram notifications:** first it tries to send an actual **photo** (`sendPhoto` / MTProto media) from `best_frame`; if that is unavailable, it falls back to a bbox crop from the video, then to a full frame. If Telegram rejects the media or the preview is broken, BirdLense falls back to a text message with link/button and records the fallback reason in observability (System → Observability).

--- a/docs/CONFIGURATION.ru.md
+++ b/docs/CONFIGURATION.ru.md
@@ -352,7 +352,7 @@ Opt-in: при `enabled=true` и `upload_url` Hub загружает лучши�
 | `notifications.paid_media_forward_star_count` | При бесплатном просмотре: 0=разрешить пересылку, >0=запретить. При платном — пересылка включена. |
 | `general.notification_excluded_species` | Виды, исключённые из уведомлений |
 | `processor.save_images` | При true — сохранять кадры детекций на диск для отладки. На отправку фото в Telegram не влияет |
-| `processor.save_dataset_crops` | При true — сохранять best_frame в `data/dataset/train/<Species>/` для экспорта и дообучения |
+| `processor.save_dataset_crops` | По умолчанию **false** (включать явно). При true — сохранять best_frame в `data/dataset/train/<Species>/` для экспорта и дообучения |
 | `processor.dataset_min_confidence` | Мин. confidence (0.0–1.0) для сохранения кадра в датасет. По умолчанию 0.5 |
 
 **Как BirdLense отправляет Telegram-уведомление:** сначала пытается отправить именно **фото** (`sendPhoto` / MTProto media) из `best_frame`; если его нет — из bbox-crop по видео; если и это не удалось — полный кадр. При ошибке Telegram или битом превью делается fallback на текстовое сообщение со ссылкой/кнопкой, а причина fallback пишется в наблюдаемость (System → Observability).

--- a/scripts/fetch-processor-weights.sh
+++ b/scripts/fetch-processor-weights.sh
@@ -107,7 +107,24 @@ ensure_two_stage_classifier() {
   fi
   echo "Downloading EU classifier weights..."
   ensure_dir "$CLASSIFIER_DEST"
-  curl -fsSL -o "$CLASSIFIER_DEST" "$CLASSIFIER_URL"
+  tmp="$(mktemp)"
+  curl -fsSL --retry 3 --retry-connrefused --retry-delay 5 -o "$tmp" "$CLASSIFIER_URL"
+  echo "Verifying classifier checksum against CHECKSUMS..."
+  expected="$(awk '/  app\/processor\/models\/classification\/weights\/best\.pt$/ {print $1}' "${ROOT}/CHECKSUMS")"
+  actual="$(sha256sum "$tmp" | awk '{print $1}')"
+  if [[ -z "$expected" ]]; then
+    echo "ERROR: CHECKSUMS entry missing for app/processor/models/classification/weights/best.pt" >&2
+    rm -f "$tmp"
+    exit 7
+  fi
+  if [[ "$expected" != "$actual" ]]; then
+    echo "ERROR: checksum mismatch for classifier weights" >&2
+    echo "expected=$expected" >&2
+    echo "actual=$actual" >&2
+    rm -f "$tmp"
+    exit 8
+  fi
+  mv "$tmp" "$CLASSIFIER_DEST"
 }
 
 if [[ "$MODE" == "legacy" ]]; then

--- a/scripts/fetch-processor-weights.sh
+++ b/scripts/fetch-processor-weights.sh
@@ -10,7 +10,8 @@ LEGACY_DEST="${ROOT}/app/yolo11n.pt"
 DETECTOR_ZIP="${DETECTOR_ZIP:-${ROOT}/app/processor/models/detection/nabirds_yolo11n_binary.zip}"
 DETECTOR_DEST="${ROOT}/app/processor/models/detection/weights/best.pt"
 CLASSIFIER_DEST="${ROOT}/app/processor/models/classification/weights/best.pt"
-CLASSIFIER_URL="${CLASSIFIER_URL:-https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/main/best.pt}"
+# Пин ревизии HF (не main): иначе при обновлении ветки ломается CHECKSUMS/CI.
+CLASSIFIER_URL="${CLASSIFIER_URL:-https://huggingface.co/gfermoto/birdlense-birds-eu/resolve/c6af5aa595cbb1198a61bcf2f3f9c2adc3772dc9/best.pt}"
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
## Сводка
Три коммита поверх `main` после мержа 0.3.4 / PR #273: правки по ревью CodeQL + CodeRabbit, второй коммит по nitpick’ам, фикс зелёного CI.

## Коммиты
- **fix(security,ci)** — `processor_routes`: regex для spectrogram, повторная проверка `VIDEO_PATH_RE`, пометки `codeql[py/path-injection]`; checksum классификатора + `curl --retry`; Dockerfile: временный файл + `sha256sum -c`; CI: retry для `fetch-processor-weights.sh`; README.ru.
- **chore** — Makefile (`all`/`clean`, `venv-web`), лог clamp confidence только по изменённым ключам, `save_dataset_crops` по умолчанию `false`, issue templates (DoD), Poetry template, CONFIGURATION.
- **fix(ci)** — верный SHA256 `best.pt` и **пин ревизии** Hugging Face (`c6af5aa…`), чтобы `main` на стороне модели не ломал CHECKSUMS.

## Проверки
CI зелёный на `dev` (подтверждено перед PR).

## Merge
Обычный merge в `main`; при релизе — тег/CHANGELOG по вашему процессу.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Новые функции**
  * Добавлена логика повтора при загрузке весов классификатора для повышения надёжности.

* **Улучшения**
  * Отключено сохранение набора данных по умолчанию (экономия дискового пространства).
  * Усилена валидация путей к файлам записей и спектрограмм.
  * Добавлена проверка контрольных сумм для загружаемых весов.
  * Улучшено логирование при корректировке параметров конфигурации.

* **Документация**
  * Обновлены инструкции по конфигурации и развёртыванию.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->