### PR TITLE
fix(deps): axios 1.15.0, vite 6.4.2 (Dependabot)

### DIFF
--- a/app/ui/package-lock.json
+++ b/app/ui/package-lock.json
@@ -20,7 +20,7 @@
         "@tanstack/react-form": "^0.42.1",
         "@tanstack/react-query": "^5.61.0",
         "@tanstack/react-query-devtools": "^5.61.0",
-        "axios": "^1.7.7",
+        "axios": "^1.15.0",
         "dayjs": "^1.11.13",
         "i18next": "^23.16.0",
         "react": "^19.0.0",
@@ -44,7 +44,7 @@
         "typedoc": "^0.27.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.15.0",
-        "vite": "^6.4.1",
+        "vite": "^6.4.2",
         "vite-plugin-pwa": "^1.2.0",
         "workbox-core": "^7.4.0",
         "workbox-precaching": "^7.4.0"
@@ -3452,12 +3452,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-macros": {
@@ -6733,8 +6735,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8215,7 +8222,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -27,7 +27,7 @@
     "@tanstack/react-form": "^0.42.1",
     "@tanstack/react-query": "^5.61.0",
     "@tanstack/react-query-devtools": "^5.61.0",
-    "axios": "^1.7.7",
+    "axios": "^1.15.0",
     "dayjs": "^1.11.13",
     "i18next": "^23.16.0",
     "react": "^19.0.0",
@@ -51,7 +51,7 @@
     "typedoc": "^0.27.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.15.0",
-    "vite": "^6.4.1",
+    "vite": "^6.4.2",
     "vite-plugin-pwa": "^1.2.0",
     "workbox-core": "^7.4.0",
     "workbox-precaching": "^7.4.0"


### PR DESCRIPTION
## Dependabot
Закрывает открытые alerts по `app/ui/package-lock.json`:
- **axios** → **1.15.0** (GHSA SSRF / NO_PROXY)
- **vite** → **6.4.2** (dev server / path issues)

`npm audit`: 0 vulnerabilities. `npm run build` — OK локально.

Коммит: `3e8a46a2`.

Made with [Cursor](https://cursor.com)