### PR TITLE
test(ui): MemoryRouter v7 future flags in tests

### DIFF
--- a/app/ui/src/pages/Timeline/TimelinePage.test.tsx
+++ b/app/ui/src/pages/Timeline/TimelinePage.test.tsx
@@ -5,6 +5,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TimelinePage } from './index';
 
+/** Align with App.tsx BrowserRouter future flags (silences v7 upgrade warnings). */
+const memoryRouterFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
 vi.mock('@mui/material/useMediaQuery', () => ({
   default: () => false,
 }));
@@ -53,7 +59,10 @@ function renderPage() {
   });
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={['/timeline?date=2026-04-15']}>
+      <MemoryRouter
+        future={memoryRouterFuture}
+        initialEntries={['/timeline?date=2026-04-15']}
+      >
         <Routes>
           <Route path="/timeline" element={<TimelinePage />} />
         </Routes>

--- a/app/ui/src/pages/Unknowns/Unknowns.test.tsx
+++ b/app/ui/src/pages/Unknowns/Unknowns.test.tsx
@@ -4,6 +4,12 @@ import { describe, expect, it } from 'vitest';
 import { UnknownCard } from './index';
 import type { UnknownDetection } from '../../api/api';
 
+/** Align with App.tsx BrowserRouter future flags (silences v7 upgrade warnings). */
+const memoryRouterFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
 const detection: UnknownDetection = {
   id: 1,
   video_id: 10,
@@ -20,7 +26,7 @@ const detection: UnknownDetection = {
 describe('UnknownCard', () => {
   it('shows localized review reason chip for operator explainability', () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter future={memoryRouterFuture}>
         <UnknownCard
           detection={detection}
           speciesList={[]}


### PR DESCRIPTION
Aligns MemoryRouter in vitest with App.tsx BrowserRouter future flags (v7_startTransition, v7_relativeSplatPath). Removes React Router upgrade warnings from test stderr.

Single commit on dev ahead of main.

Made with [Cursor](https://cursor.com)