### PR TITLE
fix(web): safe component status for readiness/status

### DIFF
--- a/app/web/routes/ui_status_push_routes.py
+++ b/app/web/routes/ui_status_push_routes.py
@@ -11,7 +11,7 @@ from auth import settings_check_access
 from models import ActivityLog, db
 from services.cache import cache_get, cache_set
 from services.api_json_validation import parse_request_json_dict
-from services.component_status_service import build_component_status_payload
+from services.component_status_service import build_component_status_payload_safe
 from services.readiness_service import build_readiness_payload
 from services.feed_service import dispense_feed, get_last_dispense
 from services.web_push_service import (
@@ -86,7 +86,7 @@ def register_ui_status_push_routes(app):
         hit, cached = cache_get("component_status:v1")
         if hit:
             return cached
-        payload = build_component_status_payload(db.session)
+        payload = build_component_status_payload_safe(db.session)
         cache_set("component_status:v1", payload, CACHE_STATUS_SEC)
         return payload
 

--- a/app/web/services/component_status_service.py
+++ b/app/web/services/component_status_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from datetime import datetime, timedelta, timezone
 
@@ -11,6 +12,8 @@ from models import ActivityLog
 from services.feed_service import check_esphome_reachable, check_mqtt_connected
 from services.status_service import check_video_reachable, parse_yolo_status_from_heartbeat
 from util import ensure_utc
+
+logger = logging.getLogger(__name__)
 
 _TRIGGER_LABELS = {
     "opencv": "OpenCV",
@@ -30,6 +33,30 @@ def _trigger_display(motion_source: str, frigate_parallel: bool) -> str:
     if motion_source == "esphome" and frigate_parallel:
         return "ESPHome + Frigate (MQTT)"
     return trigger_display
+
+
+def _fallback_component_status_payload() -> dict[str, str | None]:
+    """Минимальный payload, если основная сборка упала (деплой/verify не должны валить воркер)."""
+    return {
+        "web": "ok",
+        "processor": "unknown",
+        "video": "unknown",
+        "mqtt": "unknown",
+        "esphome": "unknown",
+        "yolo": "unknown",
+        "motion_source": "unknown",
+        "trigger_display": "unknown",
+        "birdnet_url": None,
+    }
+
+
+def build_component_status_payload_safe(session) -> dict:
+    """Как build_component_status_payload, но без необработанных исключений (readiness / status)."""
+    try:
+        return build_component_status_payload(session)
+    except Exception:
+        logger.exception("build_component_status_payload failed; using fallback")
+        return _fallback_component_status_payload()
 
 
 def build_component_status_payload(session) -> dict:

--- a/app/web/services/readiness_service.py
+++ b/app/web/services/readiness_service.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from sqlalchemy import text
 
 from data_paths import data_dir
-from services.component_status_service import build_component_status_payload
+from services.component_status_service import build_component_status_payload_safe
 
 
 def _path_status(path: Path, label: str) -> dict[str, object]:
@@ -44,6 +44,6 @@ def build_readiness_payload(session) -> tuple[dict[str, object], int]:
         "ready": ready,
         "checked_at": datetime.now(timezone.utc).isoformat(),
         "checks": checks,
-        "components": build_component_status_payload(session),
+        "components": build_component_status_payload_safe(session),
     }
     return payload, (200 if ready else 503)

--- a/app/web/tests/test_api.py
+++ b/app/web/tests/test_api.py
@@ -672,6 +672,20 @@ class TestHealth:
         assert r.json["checks"]["database"]["status"] == "error"
         assert r.json["checks"]["database"]["error"] == "database_unavailable"
 
+    def test_readiness_survives_component_status_exception(self, client, monkeypatch):
+        import services.component_status_service as cs
+
+        def _boom(_session):
+            raise RuntimeError("boom components")
+
+        monkeypatch.setattr(cs, "build_component_status_payload", _boom)
+        r = client.get("/api/ui/readiness")
+        assert r.status_code == 200
+        data = r.json
+        assert data["ready"] is True
+        assert data["components"]["web"] == "ok"
+        assert data["components"]["processor"] == "unknown"
+
 
 class TestStatus:
     def test_status_returns_component_status(self, client):
@@ -697,6 +711,21 @@ class TestStatus:
         r = client.get("/api/ui/status")
         assert r.status_code == 200
         assert r.json["esphome"] in ("ok", "error", "not_configured", "not_used")
+
+    def test_status_survives_component_status_exception(self, client, monkeypatch):
+        from services.cache import cache_delete
+
+        import services.component_status_service as cs
+
+        def _boom(_session):
+            raise RuntimeError("boom components")
+
+        cache_delete("component_status:v1")
+        monkeypatch.setattr(cs, "build_component_status_payload", _boom)
+        r = client.get("/api/ui/status")
+        assert r.status_code == 200
+        assert r.json["web"] == "ok"
+        assert r.json["processor"] == "unknown"
 
 
 class TestSettings:


### PR DESCRIPTION
## Problem

GitHub Deploy workflow failed on verify: after `health: OK`, `/api/ui/readiness` got `curl (52) Empty reply` then connection refused — gunicorn worker died while building component status (MQTT/go2rtc/heartbeat path).

Run: https://github.com/Gfermoto/BirdLense-Hub/actions/runs/24475705855

## Change

- `build_component_status_payload_safe()` — try/except with structured fallback + log.
- Used from `readiness_service` and `/api/ui/status`.
- Tests: readiness and status survive injected exception in `build_component_status_payload`.

Made with [Cursor](https://cursor.com)