### PR TITLE
chore: prune legacy user_config, MCP verify, go2rtc log level

### DIFF
--- a/app/processor/src/sources/go2rtc_stream_source.py
+++ b/app/processor/src/sources/go2rtc_stream_source.py
@@ -140,7 +140,8 @@ class Go2RTCStreamSource:
         if not self.auto_reconnect:
             return False
         while True:
-            self.logger.warning(f"Reconnecting in {self._reconnect_delay}s...")
+            # Ожидаемое поведение при кратковременных обрывах RTSP; не WARNING — иначе шум в логах/алертах.
+            self.logger.info("Reconnecting in %ss...", self._reconnect_delay)
             time.sleep(self._reconnect_delay)
             if self._connect():
                 return True

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -64,6 +64,32 @@ Typical fixes:
 - fix ownership (`uid 1000`) or host filesystem permissions
 - inspect DB path / volume mount under `DATA_DIR`
 
+## Legacy keys in config-audit (gallery / Heimdall)
+
+If `GET /api/ui/system/config-audit` still lists deprecated keys such as `gallery.*` or `general.heimdall_url`, they are coming from **`app/app_config/user_config.yaml`** on the hub (the UI never returns real secrets, so you cannot “copy” them out for cleanup).
+
+On the server (adjust paths to your deploy directory):
+
+```bash
+cd /root/BirdLense
+python3 scripts/prune_deprecated_user_config.py --path app/app_config/user_config.yaml --dry-run
+python3 scripts/prune_deprecated_user_config.py --path app/app_config/user_config.yaml
+cd app && docker compose restart birdlense
+```
+
+The script writes `user_config.yaml.bak` next to the file before replacing it. See also [SECRETS_ROTATION](./SECRETS_ROTATION.md).
+
+## MCP smoke check (Bearer token)
+
+Use the **same** secret as on the hub: `MCP_TOKEN` in `app/.env` (or `mcp.token` in UI, not the masked `***`).
+
+```bash
+export MCP_TOKEN='your-token-from-server-env'
+./scripts/verify-mcp.sh https://YOUR_HOST/
+```
+
+Details: [MCP_SETUP](./MCP_SETUP.md).
+
 ## Request-level debugging
 
 Every API response now includes `X-Request-ID`.

--- a/docs/RUNBOOKS.ru.md
+++ b/docs/RUNBOOKS.ru.md
@@ -64,6 +64,32 @@ ssh ВАШ_SSH_ХОСТ "tail -100 ВАШ_УДАЛЁННЫЙ_КАТАЛОГ/app/
 - поправить владельца (`uid 1000`) или права на хосте;
 - проверить путь к БД и volume в `DATA_DIR`.
 
+## Устаревшие ключи в config-audit (gallery / Heimdall)
+
+Если `GET /api/ui/system/config-audit` всё ещё показывает `gallery.*` или `general.heimdall_url`, они живут в **`app/app_config/user_config.yaml`** на хабе (в API токены/секреты замаскированы, «вытащить» их для чистки нельзя).
+
+На сервере (путь к деплою подставьте свой):
+
+```bash
+cd /root/BirdLense
+python3 scripts/prune_deprecated_user_config.py --path app/app_config/user_config.yaml --dry-run
+python3 scripts/prune_deprecated_user_config.py --path app/app_config/user_config.yaml
+cd app && docker compose restart birdlense
+```
+
+Перед записью создаётся резервная копия `user_config.yaml.bak`. См. также [SECRETS_ROTATION](./SECRETS_ROTATION.ru.md).
+
+## Быстрая проверка MCP (Bearer)
+
+Нужен **тот же** секрет, что на хабе: `MCP_TOKEN` в `app/.env` (или `mcp.token` в UI — не строка `***` из GET settings).
+
+```bash
+export MCP_TOKEN='ваш-токен-с-сервера'
+./scripts/verify-mcp.sh https://ВАШ_ХОСТ/
+```
+
+Подробнее: [MCP_SETUP.ru](./MCP_SETUP.ru.md).
+
 ## Отладка по запросам
 
 Каждый ответ API содержит заголовок `X-Request-ID`.

--- a/scripts/prune_deprecated_user_config.py
+++ b/scripts/prune_deprecated_user_config.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Удалить из user_config.yaml устаревшие ключи (gallery, heimdall_url и др.).
+
+Список ключей совпадает с DEPRECATED_USER_CONFIG_KEYS в system_config_audit_service,
+плюс целиком удаляется верхнеуровневый блок ``gallery``, если остался после точечных удалений.
+
+Примеры:
+  python3 scripts/prune_deprecated_user_config.py --dry-run
+  python3 scripts/prune_deprecated_user_config.py --path /root/BirdLense/app/app_config/user_config.yaml
+
+Перед записью создаётся резервная копия ``<path>.bak`` (перезаписывается).
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WEB_ROOT = _REPO_ROOT / "app" / "web"
+if str(_WEB_ROOT) not in sys.path:
+    sys.path.insert(0, str(_WEB_ROOT))
+
+from services.system_config_audit_service import DEPRECATED_USER_CONFIG_KEYS  # noqa: E402
+
+
+def _delete_dotted(cfg: dict, dotted: str) -> bool:
+    parts = dotted.split(".")
+    cur: dict = cfg
+    for p in parts[:-1]:
+        nxt = cur.get(p)
+        if not isinstance(nxt, dict):
+            return False
+        cur = nxt
+    last = parts[-1]
+    if last in cur:
+        del cur[last]
+        return True
+    return False
+
+
+def _prune_empty_dicts(node: dict) -> None:
+    """Рекурсивно удалить пустые dict-значения (после вычищения листьев)."""
+    if not isinstance(node, dict):
+        return
+    for k in list(node.keys()):
+        v = node[k]
+        if isinstance(v, dict):
+            _prune_empty_dicts(v)
+            if v == {}:
+                del node[k]
+
+
+def prune_user_config(cfg: dict) -> tuple[int, list[str]]:
+    removed: list[str] = []
+    for dotted in DEPRECATED_USER_CONFIG_KEYS:
+        if _delete_dotted(cfg, dotted):
+            removed.append(dotted)
+    if isinstance(cfg.get("gallery"), dict):
+        del cfg["gallery"]
+        removed.append("gallery (entire block)")
+    elif "gallery" in cfg:
+        del cfg["gallery"]
+        removed.append("gallery (non-dict removed)")
+    _prune_empty_dicts(cfg)
+    return len(removed), removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Prune deprecated keys from BirdLense user_config.yaml")
+    parser.add_argument(
+        "--path",
+        default=str(_REPO_ROOT / "app" / "app_config" / "user_config.yaml"),
+        help="Path to user_config.yaml",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print changes only, do not write")
+    args = parser.parse_args()
+    path = Path(args.path)
+    if not path.is_file():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+    raw = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        print("error: YAML root must be a mapping", file=sys.stderr)
+        return 2
+    before = yaml.safe_dump(data, sort_keys=True, allow_unicode=True)
+    n, keys = prune_user_config(data)
+    after = yaml.safe_dump(data, sort_keys=True, allow_unicode=True)
+    if n == 0:
+        print("no deprecated keys to remove")
+    else:
+        print(f"would remove {n} entries:")
+        for k in keys:
+            print(f"  - {k}")
+    if before == after:
+        print("no changes needed")
+        return 0
+    if args.dry_run:
+        print("dry-run: not writing")
+        return 0
+    bak = path.with_suffix(path.suffix + ".bak")
+    shutil.copy2(path, bak)
+    path.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True, default_flow_style=False),
+        encoding="utf-8",
+    )
+    print(f"wrote {path} (backup {bak})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-mcp.sh
+++ b/scripts/verify-mcp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Smoke-check MCP на развёрнутом хабе (нужен реальный MCP_TOKEN из app/.env на сервере).
+# Использование:
+#   export MCP_TOKEN='...'   # или: MCP_TOKEN=... ./scripts/verify-mcp.sh https://birdlense.example/
+#   ./scripts/verify-mcp.sh https://birdlense.example/
+set -euo pipefail
+
+BASE_URL="${1:-http://127.0.0.1:8085}"
+BASE_URL="${BASE_URL%/}"
+TOKEN="${MCP_TOKEN:-}"
+
+if [[ -z "${TOKEN}" ]]; then
+  echo "error: set MCP_TOKEN (same value as on the hub: MCP_TOKEN or mcp.token)" >&2
+  exit 2
+fi
+
+body='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify-mcp.sh","version":"1.0"}}}'
+tmp="$(mktemp)"
+code="$(curl -sS -o "${tmp}" -w '%{http_code}' --max-time 20 \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -X POST "${BASE_URL}/mcp" \
+  -d "${body}" || true)"
+
+echo "POST ${BASE_URL}/mcp (initialize) -> HTTP ${code}"
+head -c 500 "${tmp}" || true
+echo
+rm -f "${tmp}"
+
+if [[ "${code}" != "200" ]]; then
+  echo "error: expected HTTP 200 from initialize" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/prune_deprecated_user_config.py` to remove deprecated gallery/heimdall keys from `user_config.yaml` (backup `.bak`).
- Add `scripts/verify-mcp.sh` for MCP `initialize` smoke against `/mcp`.
- Document both in RUNBOOKS (EN/RU).
- Lower go2rtc reconnect message from WARNING to INFO (expected RTSP blips).

## Ops note

Production `user_config` was already pruned on VPS; this PR aligns repo + future deploys.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности

* **Новые функции**
  * Добавлены скрипты для удаления устаревших параметров конфигурации с поддержкой предварительного просмотра изменений.
  * Реализован инструмент проверки подключения MCP.

* **Документация**
  * Добавлены новые инструкции оператора по управлению конфигурацией в RUNBOOKS на английском и русском языках.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->