### PR TITLE
fix(nginx): allowlist /data/ — закрытие утечки #339

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **[#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339):** nginx больше не отдаёт весь volume `DATA_DIR` по префиксу `/data/`. Разрешены только **`/data/recordings/`**, **`/data/images/`**, **`/data/file_test/`** (видео, картинки каталога, file-replay); остальное, включая **`/data/db/*.db`**, датасет и кэш, получает **403** (`app/nginx/standalone.conf.template`, `standalone.conf`, `default.conf`).
+
 ### Changed
 
 - **Документация (CONFIGURATION):** EN/RU — блок **On this page** / **По странице** (быстрые якоря), ссылки на **`app/.env.example`** и **`docs/project/openapi.md`** в шапке; **I18N_STATUS** — строка **SETTINGS_TRIGGERS_PHASE2**, шаг про OpenAPI/contract-тест при смене HTTP-маршрутов.

--- a/app/nginx/default.conf
+++ b/app/nginx/default.conf
@@ -29,10 +29,24 @@ server {
     autoindex on; # Enables directory listing
   }
 
-  # Serve media files (e.g., /data/recordings/2026/03/08/214914/video.mp4)
-  location /data/ {
-    alias /srv/data/;
-    autoindex off;  # No folder listing - use Timeline in the app
+  # #339: только recordings/images/file_test; не отдаём /srv/data/db и прочее.
+  location ^~ /data/recordings/ {
+    alias /srv/data/recordings/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /srv/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /srv/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   # Static UI (built into nginx image)

--- a/app/nginx/examples/recordings_allowlist.conf.snippet
+++ b/app/nginx/examples/recordings_allowlist.conf.snippet
@@ -1,6 +1,7 @@
 # Example: restrict direct access to recordings by client IP (nginx).
-# Product default: location /data/ in standalone.conf.template serves all of /app/data/.
-# Threat: predictable paths .../recordings/YYYY/MM/DD/HHMMSS/video.mp4 without HTTP auth.
+# Product default (#339): standalone.conf.template allowlists only /data/recordings/,
+# /data/images/, /data/file_test/ — не весь volume (SQLite db/, dataset/, cache/ — 403).
+# Threat (остаётся): предсказуемые URL записей без HTTP auth — ниже IP-allowlist при необходимости.
 #
 # How to use:
 # 1) Merge into server { } in the generated default.conf (after entrypoint), or maintain a fork

--- a/app/nginx/standalone.conf
+++ b/app/nginx/standalone.conf
@@ -26,11 +26,24 @@ server {
   # Защита от path traversal
   if ($request_uri ~* "\.\.") { return 403; }
 
-  # Записи: /data/recordings/... -> /app/data/recordings/
-  location /data/ {
-    alias /app/data/;
+  # #339: только публичные медиа; db/dataset/cache и пр. под /data/ — 403.
+  location ^~ /data/recordings/ {
+    alias /app/data/recordings/;
     autoindex off;
     add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /app/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /app/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   location / {

--- a/app/nginx/standalone.conf.template
+++ b/app/nginx/standalone.conf.template
@@ -27,10 +27,24 @@ server {
   # Защита от path traversal
   if ($request_uri ~* "\.\.") { return 403; }
 
-  location /data/ {
-    alias /app/data/;
+  # #339: не отдаём весь DATA_DIR — иначе скачиваем SQLite (db/), датасет, кэш без auth.
+  location ^~ /data/recordings/ {
+    alias /app/data/recordings/;
     autoindex off;
     add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /app/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /app/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   location / {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,11 +52,12 @@
 | Risk | Description | Recommendation |
 |------|--------------|----------------|
 | ~~**Critical**~~ **Fixed** | `location /data/` with `alias /app/data/` — request `/data/../.env` could read `/app/.env`. | Added check `if ($request_uri ~* "\.\.") { return 403; }` in all nginx configs. |
+| ~~**Critical**~~ **Fixed** | Same broad `/data/` alias exposed the whole volume: e.g. **`/data/db/birdlense.db`**, dataset crops, cache — no HTTP auth. | **Allowlist** in nginx: only `/data/recordings/`, `/data/images/`, `/data/file_test/`; any other `/data/*` → **403** ([#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339)). |
 | **High** | `/data/recordings/` accessible without authentication. Path `YYYY/MM/DD/HHMMSS/video.mp4` is predictable. | Add access check via API with auth or restrict by IP. |
 
 **Mitigations (pick one for production exposure):** (1) **IP allowlist** — more specific `location ^~ /data/recordings/` with `allow`/`deny` (see `app/nginx/examples/recordings_allowlist.conf.snippet` and [DEPLOY_SERVER.md §8](./DEPLOY_SERVER.md)); (2) **no direct nginx media** — reverse proxy only passes `/api/…` and authenticated stream routes; (3) **`auth_request`** to the Hub session endpoint — advanced, not shipped by default.
 
-**Test:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — if vulnerable, returns 200.
+**Tests:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — if vulnerable, returns 200. **`curl -I "http://YOUR_HOST:8085/data/db/birdlense.db"`** — must be **403** (not `application/octet-stream`).
 
 ---
 

--- a/docs/SECURITY.ru.md
+++ b/docs/SECURITY.ru.md
@@ -52,11 +52,12 @@
 | Риск | Описание | Рекомендация |
 |------|----------|--------------|
 | ~~**Критический**~~ **Исправлено** | `location /data/` + `alias` — запрос `/data/../.env`. | Проверка `..` в URI → 403 во всех конфигах nginx. |
+| ~~**Критический**~~ **Исправлено** | Тот же широкий alias отдавал весь volume: **`/data/db/birdlense.db`**, кропы датасета, кэш — без HTTP-auth. | **Allowlist** в nginx: только `/data/recordings/`, `/data/images/`, `/data/file_test/`; остальное под `/data/*` → **403** ([#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339)). |
 | **Высокий** | `/data/recordings/` без аутентификации; предсказуемые пути к `video.mp4`. | Выдача через API с auth или ограничение по IP. |
 
 **Смягчение (на выбор при публичном доступе):** (1) **allowlist по IP** — отдельный `location ^~ /data/recordings/` с `allow`/`deny` (пример `app/nginx/examples/recordings_allowlist.conf.snippet`, [DEPLOY_SERVER.ru.md §8](./DEPLOY_SERVER.ru.md)); (2) **без прямой раздачи медиа** — снаружи только reverse proxy на `/api/…` и авторизованные stream-роуты; (3) **`auth_request`** к сессии Hub — сложнее, в образ по умолчанию не входит.
 
-**Проверка:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — при уязвимости будет 200.
+**Проверки:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — при уязвимости будет 200. **`curl -I "http://YOUR_HOST:8085/data/db/birdlense.db"`** — должно быть **403** (не `application/octet-stream`).
 
 ---
 


### PR DESCRIPTION
## Summary

- nginx больше не отдаёт **весь** `DATA_DIR` по `/data/` (раньше можно было скачать **SQLite**, датасет, кэш без auth).
- Разрешены только **`/data/recordings/`**, **`/data/images/`**, **`/data/file_test/`**; остальное под `/data/` → **403**.
- Файлы: `standalone.conf.template`, `standalone.conf`, `default.conf`, пример `recordings_allowlist.conf.snippet`, `CHANGELOG`, `SECURITY` EN/RU.

## Verify after deploy

```bash
curl -I "https://<hub>/data/db/birdlense.db"   # expect 403
curl -I "https://<hub>/data/recordings/"       # 404 or dir behavior; a real mp4 path should still 200
```

## Tests

- `pytest app/web/tests/test_security_hardening.py` — 21 passed locally.

Closes #339

Made with [Cursor](https://cursor.com)