### PR TITLE
test(processor): runtime stats edge cases (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Coverage настроек:** из `AUTO_ALLOWLIST_KEYS` убраны ключи, для которых уже есть `form.Field` в дереве Settings (меньше ложного «planned-ui» для полей с UI).
 
+- **[#340](https://github.com/Gfermoto/BirdLense-Hub/issues/340):** тесты `processor_runtime_stats` для больших байтовых gauge (порядка 100 GiB), окна latency с `maxlen=200` и отрицательных сэмплов; в миграции **`004_birdnet_fifo_event`** уточнено, что `sa.JSON()` на PostgreSQL создаётся как JSONB (SQLAlchemy 2.x).
+
 ---
 
 ## [0.3.6] - 2026-04-21

--- a/app/processor/tests/test_processor_runtime_stats.py
+++ b/app/processor/tests/test_processor_runtime_stats.py
@@ -26,6 +26,43 @@ def test_runtime_stats_snapshot_persists_metrics(tmp_path, monkeypatch):
     assert body["latency_ms"]["frame_processor_detect_p95"] == 55.0
 
 
+def test_runtime_stats_large_disk_style_gauge_serializes(tmp_path, monkeypatch):
+    """Гигабайтные счётчики диска остаются целыми в JSON (#340)."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    hundred_gib = 100 * 1024**3
+    prs.set_gauge("recording_disk_bytes_used", hundred_gib)
+    path = prs.flush_runtime_stats_snapshot(force=True)
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["gauges"]["recording_disk_bytes_used"] == hundred_gib
+
+
+def test_observe_timing_maxlen_keeps_last_samples(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    for i in range(250):
+        prs.observe_timing("frame_processor_detect", float(i))
+    snap = prs.runtime_stats_snapshot()
+    assert snap["latency_ms"]["frame_processor_detect_count"] == 200
+    assert snap["latency_ms"]["frame_processor_detect_last"] == 249.0
+
+
+def test_observe_timing_ignores_negative(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    prs.observe_timing("x", -5.0)
+    assert "x_count" not in prs.runtime_stats_snapshot()["latency_ms"]
+
+
 def test_runtime_stats_write_failure_does_not_raise(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 

--- a/app/web/migrations/versions/004_birdnet_fifo_event.py
+++ b/app/web/migrations/versions/004_birdnet_fifo_event.py
@@ -25,6 +25,7 @@ def upgrade():
         "birdnet_fifo_event",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("ts_epoch", sa.Float(), nullable=False),
+        # SA 2.x: на PostgreSQL колонка создаётся как JSONB, на SQLite — JSON.
         sa.Column("payload", sa.JSON(), nullable=False),
     )
     op.create_index(


### PR DESCRIPTION
## Что сделано
- Тесты `processor_runtime_stats`: большой целочисленный gauge (~100 GiB), окно latency при 250 сэмплах (maxlen 200), игнор отрицательных таймингов.
- Комментарий в миграции `004_birdnet_fifo_event`: `sa.JSON()` → JSONB на PostgreSQL (SA 2.x), JSON на SQLite.

## Проверка
`python3 -m pytest app/processor/tests/test_processor_runtime_stats.py -q`

Closes #340

Made with [Cursor](https://cursor.com)