### PR TITLE
fix(web): upload Content-Encoding guard (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- **[#341](https://github.com/Gfermoto/BirdLense-Hub/issues/341):** на POST upload-роутах (веса процессора, file-test, restore SQLite, YAML import) отклоняется непустой **`Content-Encoding`**, кроме единственного значения **`identity`** — снижает риск decompression bomb при нетипичных клиентах (`services/upload_request_encoding_guard.py`). Путь из ревью `processor.js` / `uploads.js` в этом репозитории отсутствует; дублирующих Flask-логгеров по коду не найдено.
+
 - **[#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339):** nginx больше не отдаёт весь volume `DATA_DIR` по префиксу `/data/`. Разрешены только **`/data/recordings/`**, **`/data/images/`**, **`/data/file_test/`** (видео, картинки каталога, file-replay); остальное, включая **`/data/db/*.db`**, датасет и кэш, получает **403** (`app/nginx/standalone.conf.template`, `standalone.conf`, `default.conf`).
 
 ### Changed

--- a/app/web/extensions.py
+++ b/app/web/extensions.py
@@ -13,6 +13,9 @@ from services.session_idle_service import register_session_idle_middleware
 from services.strict_ui_api_auth_service import (
     register_strict_ui_api_auth_middleware,
 )
+from services.upload_request_encoding_guard import (
+    register_upload_request_encoding_guard,
+)
 
 migrate = Migrate()
 
@@ -27,3 +30,4 @@ def init_extensions(app: Flask) -> None:
     migrate.init_app(app, db, directory=migrations_dir)
     register_strict_ui_api_auth_middleware(app)
     register_session_idle_middleware(app)
+    register_upload_request_encoding_guard(app)

--- a/app/web/services/upload_request_encoding_guard.py
+++ b/app/web/services/upload_request_encoding_guard.py
@@ -1,0 +1,62 @@
+"""Ограничение Content-Encoding на upload-роутах (#341).
+
+Классический риск: маленький gzip/deflate/brotli body с огромным распакованным
+объёмом (bomb), если где-то в цепочке прозрачно декодируют тело запроса.
+Браузеры при multipart/file не выставляют Content-Encoding на сжатие тела;
+нормальный клиент загружает сырой multipart.
+"""
+
+from __future__ import annotations
+
+from flask import Flask, jsonify, request
+
+# Пути: multipart / файлы (см. routes/* upload, yaml-import).
+_UPLOAD_PATHS: frozenset[str] = frozenset(
+    {
+        "/api/ui/system/processor-weights/upload",
+        "/api/ui/system/file-test/upload",
+        "/api/ui/system/db/restore",
+        "/api/ui/settings/yaml-import",
+    }
+)
+
+
+def _content_encoding_tokens() -> list[str]:
+    raw = (request.headers.get("Content-Encoding") or "").strip()
+    if not raw:
+        return []
+    out: list[str] = []
+    for part in raw.split(","):
+        p = part.split(";", 1)[0].strip().lower()
+        if p:
+            out.append(p)
+    return out
+
+
+def register_upload_request_encoding_guard(app: Flask) -> None:
+    """Зарегистрировать before_request: отсечь сжатые тела на upload-URL."""
+
+    @app.before_request
+    def _reject_compressed_upload_encoding():
+        if request.method != "POST":
+            return None
+        if (request.path or "") not in _UPLOAD_PATHS:
+            return None
+        tokens = _content_encoding_tokens()
+        if not tokens:
+            return None
+        if tokens == ["identity"]:
+            return None
+        detail = (
+            "Do not send gzip/deflate/brotli (or stacked encodings) on file "
+            "upload requests; send uncompressed multipart."
+        )
+        return (
+            jsonify(
+                {
+                    "error": "Unsupported Content-Encoding on upload",
+                    "detail": detail,
+                }
+            ),
+            415,
+        )

--- a/app/web/tests/test_upload_request_encoding_guard.py
+++ b/app/web/tests/test_upload_request_encoding_guard.py
@@ -1,0 +1,41 @@
+"""#341: запрет сжатого Content-Encoding на upload-эндпоинтах."""
+
+from __future__ import annotations
+
+
+def test_upload_rejects_gzip_content_encoding(client):
+    """gzip в заголовке → 415 до декораторов auth."""
+    r = client.post(
+        "/api/ui/system/processor-weights/upload",
+        headers={"Content-Encoding": "gzip"},
+        data=b"x",
+    )
+    assert r.status_code == 415
+    body = r.get_json()
+    assert body.get("error")
+
+
+def test_upload_allows_missing_content_encoding(client):
+    """Без Content-Encoding доходит до вью (не 415)."""
+    r = client.post("/api/ui/system/processor-weights/upload", data={})
+    assert r.status_code != 415
+
+
+def test_yaml_import_rejects_br(client):
+    """Brotli token → 415."""
+    r = client.post(
+        "/api/ui/settings/yaml-import",
+        headers={"Content-Encoding": "br"},
+        data=b"x",
+    )
+    assert r.status_code == 415
+
+
+def test_upload_allows_identity_only(client):
+    """Явный identity разрешён."""
+    r = client.post(
+        "/api/ui/system/file-test/upload",
+        headers={"Content-Encoding": "identity"},
+        data={},
+    )
+    assert r.status_code != 415


### PR DESCRIPTION
## Контекст
Issue [#341](https://github.com/Gfermoto/BirdLense-Hub/issues/341) ссылался на `processor.js` / `uploads.js` — в Hub этого нет; эквивалент риска DoS через сжатое тело — **guard на Flask** до вью.

## Изменения
- `register_upload_request_encoding_guard`: POST на путях upload / yaml-import / db restore → **415**, если `Content-Encoding` задан и это не единственный `identity`.
- Тесты, CHANGELOG.

Closes #341

Made with [Cursor](https://cursor.com)