### PR TITLE
merge: dev → main (nginx #339, runtime stats #340, CI audit)

### DIFF
--- a/.github/workflows/catalog-cards-audit.yml
+++ b/.github/workflows/catalog-cards-audit.yml
@@ -32,11 +32,16 @@ jobs:
         env:
           BASE_URL_INPUT: ${{ github.event.inputs.base_url }}
           HUB_AUDIT_DEFAULT: ${{ vars.CATALOG_CARDS_AUDIT_URL }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           BASE_URL="${BASE_URL_INPUT:-}"
           if [ -z "$BASE_URL" ]; then BASE_URL="${HUB_AUDIT_DEFAULT:-}"; fi
           if [ -z "$BASE_URL" ]; then
+            if [ "${EVENT_NAME}" = "schedule" ]; then
+              echo "::notice::Catalog cards audit skipped (no CATALOG_CARDS_AUDIT_URL). Set repo variable Actions → Variables → CATALOG_CARDS_AUDIT_URL to enable nightly runs, or use workflow_dispatch with base_url."
+              exit 0
+            fi
             echo "::error::No base URL: set repository variable CATALOG_CARDS_AUDIT_URL (Settings → Secrets and variables → Actions → Variables) or run workflow_dispatch with base_url."
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **[#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339):** nginx больше не отдаёт весь volume `DATA_DIR` по префиксу `/data/`. Разрешены только **`/data/recordings/`**, **`/data/images/`**, **`/data/file_test/`** (видео, картинки каталога, file-replay); остальное, включая **`/data/db/*.db`**, датасет и кэш, получает **403** (`app/nginx/standalone.conf.template`, `standalone.conf`, `default.conf`).
+
 ### Changed
 
 - **Документация (CONFIGURATION):** EN/RU — блок **On this page** / **По странице** (быстрые якоря), ссылки на **`app/.env.example`** и **`docs/project/openapi.md`** в шапке; **I18N_STATUS** — строка **SETTINGS_TRIGGERS_PHASE2**, шаг про OpenAPI/contract-тест при смене HTTP-маршрутов.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Coverage настроек:** из `AUTO_ALLOWLIST_KEYS` убраны ключи, для которых уже есть `form.Field` в дереве Settings (меньше ложного «planned-ui» для полей с UI).
 
+- **[#340](https://github.com/Gfermoto/BirdLense-Hub/issues/340):** тесты `processor_runtime_stats` для больших байтовых gauge (порядка 100 GiB), окна latency с `maxlen=200` и отрицательных сэмплов; в миграции **`004_birdnet_fifo_event`** уточнено, что `sa.JSON()` на PostgreSQL создаётся как JSONB (SQLAlchemy 2.x).
+
 ---
 
 ## [0.3.6] - 2026-04-21

--- a/app/nginx/default.conf
+++ b/app/nginx/default.conf
@@ -29,10 +29,24 @@ server {
     autoindex on; # Enables directory listing
   }
 
-  # Serve media files (e.g., /data/recordings/2026/03/08/214914/video.mp4)
-  location /data/ {
-    alias /srv/data/;
-    autoindex off;  # No folder listing - use Timeline in the app
+  # #339: только recordings/images/file_test; не отдаём /srv/data/db и прочее.
+  location ^~ /data/recordings/ {
+    alias /srv/data/recordings/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /srv/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /srv/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   # Static UI (built into nginx image)

--- a/app/nginx/examples/recordings_allowlist.conf.snippet
+++ b/app/nginx/examples/recordings_allowlist.conf.snippet
@@ -1,6 +1,7 @@
 # Example: restrict direct access to recordings by client IP (nginx).
-# Product default: location /data/ in standalone.conf.template serves all of /app/data/.
-# Threat: predictable paths .../recordings/YYYY/MM/DD/HHMMSS/video.mp4 without HTTP auth.
+# Product default (#339): standalone.conf.template allowlists only /data/recordings/,
+# /data/images/, /data/file_test/ — не весь volume (SQLite db/, dataset/, cache/ — 403).
+# Threat (остаётся): предсказуемые URL записей без HTTP auth — ниже IP-allowlist при необходимости.
 #
 # How to use:
 # 1) Merge into server { } in the generated default.conf (after entrypoint), or maintain a fork

--- a/app/nginx/standalone.conf
+++ b/app/nginx/standalone.conf
@@ -26,11 +26,24 @@ server {
   # Защита от path traversal
   if ($request_uri ~* "\.\.") { return 403; }
 
-  # Записи: /data/recordings/... -> /app/data/recordings/
-  location /data/ {
-    alias /app/data/;
+  # #339: только публичные медиа; db/dataset/cache и пр. под /data/ — 403.
+  location ^~ /data/recordings/ {
+    alias /app/data/recordings/;
     autoindex off;
     add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /app/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /app/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   location / {

--- a/app/nginx/standalone.conf.template
+++ b/app/nginx/standalone.conf.template
@@ -27,10 +27,24 @@ server {
   # Защита от path traversal
   if ($request_uri ~* "\.\.") { return 403; }
 
-  location /data/ {
-    alias /app/data/;
+  # #339: не отдаём весь DATA_DIR — иначе скачиваем SQLite (db/), датасет, кэш без auth.
+  location ^~ /data/recordings/ {
+    alias /app/data/recordings/;
     autoindex off;
     add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/images/ {
+    alias /app/data/images/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/file_test/ {
+    alias /app/data/file_test/;
+    autoindex off;
+    add_header Accept-Ranges bytes;
+  }
+  location ^~ /data/ {
+    return 403;
   }
 
   location / {

--- a/app/processor/tests/test_processor_runtime_stats.py
+++ b/app/processor/tests/test_processor_runtime_stats.py
@@ -26,6 +26,43 @@ def test_runtime_stats_snapshot_persists_metrics(tmp_path, monkeypatch):
     assert body["latency_ms"]["frame_processor_detect_p95"] == 55.0
 
 
+def test_runtime_stats_large_disk_style_gauge_serializes(tmp_path, monkeypatch):
+    """Гигабайтные счётчики диска остаются целыми в JSON (#340)."""
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    hundred_gib = 100 * 1024**3
+    prs.set_gauge("recording_disk_bytes_used", hundred_gib)
+    path = prs.flush_runtime_stats_snapshot(force=True)
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["gauges"]["recording_disk_bytes_used"] == hundred_gib
+
+
+def test_observe_timing_maxlen_keeps_last_samples(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    for i in range(250):
+        prs.observe_timing("frame_processor_detect", float(i))
+    snap = prs.runtime_stats_snapshot()
+    assert snap["latency_ms"]["frame_processor_detect_count"] == 200
+    assert snap["latency_ms"]["frame_processor_detect_last"] == 249.0
+
+
+def test_observe_timing_ignores_negative(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+
+    import processor_runtime_stats as prs
+
+    prs.reset_runtime_stats_for_tests()
+    prs.observe_timing("x", -5.0)
+    assert "x_count" not in prs.runtime_stats_snapshot()["latency_ms"]
+
+
 def test_runtime_stats_write_failure_does_not_raise(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
 

--- a/app/web/migrations/versions/004_birdnet_fifo_event.py
+++ b/app/web/migrations/versions/004_birdnet_fifo_event.py
@@ -25,6 +25,7 @@ def upgrade():
         "birdnet_fifo_event",
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("ts_epoch", sa.Float(), nullable=False),
+        # SA 2.x: на PostgreSQL колонка создаётся как JSONB, на SQLite — JSON.
         sa.Column("payload", sa.JSON(), nullable=False),
     )
     op.create_index(

--- a/app/web/observer_time.py
+++ b/app/web/observer_time.py
@@ -51,10 +51,10 @@ def fetch_sun_times(date_str: str) -> dict | None:
 
 @lru_cache(maxsize=32)
 def _observer_timezone_name_cached(lat: str, lon: str) -> str:
-    import zoneinfo
-    from timezonefinder import TimezoneFinder
-
     try:
+        import zoneinfo
+        from timezonefinder import TimezoneFinder
+
         lat_f = float(str(lat).replace(",", "."))
         lon_f = float(str(lon).replace(",", "."))
         tf = TimezoneFinder()

--- a/app/web/tests/conftest.py
+++ b/app/web/tests/conftest.py
@@ -83,6 +83,12 @@ def _reset_global_test_state():
             _cache._store.clear()
     except Exception:
         pass
+    try:
+        from observer_time import _observer_timezone_name_cached
+
+        _observer_timezone_name_cached.cache_clear()
+    except Exception:
+        pass
     # Reset UI long-job status (shared module, not ui_system_routes)
     try:
         import routes.ui_system_jobs_state as _js

--- a/app/web/tests/test_api.py
+++ b/app/web/tests/test_api.py
@@ -2569,8 +2569,13 @@ class TestSpeciesSummaryReadOnly:
     def test_summary_hourly_activity_uses_observer_local_hour(self, app, client):
         from app_config.app_config import app_config
         from models import Species, SpeciesVisit, db
+        from observer_time import observer_local_hour
 
         unique = f"API Summary Time Owl {id(app)}"
+        # Rolling last_30d window uses real "now"; fixed March dates fall out of range in April+.
+        now_utc = datetime.now(timezone.utc)
+        visit_start = (now_utc - timedelta(hours=2)).replace(tzinfo=None, microsecond=0)
+        visit_end = visit_start + timedelta(minutes=10)
         with app.app_context():
             app_config.set("secrets.latitude", "55.7558")
             app_config.set("secrets.longitude", "37.6176")
@@ -2580,20 +2585,21 @@ class TestSpeciesSummaryReadOnly:
             db.session.add(
                 SpeciesVisit(
                     species_id=sp.id,
-                    start_time=datetime(2026, 3, 24, 21, 15, 0),
-                    end_time=datetime(2026, 3, 24, 21, 25, 0),
+                    start_time=visit_start,
+                    end_time=visit_end,
                     max_simultaneous=4,
                 ),
             )
             db.session.commit()
             sid = sp.id
+            expected_hour = observer_local_hour(visit_start.replace(tzinfo=timezone.utc))
         from services.http_response_cache import bust_response_caches
 
         bust_response_caches()
         r = client.get(f"/api/ui/species/{sid}/summary")
         assert r.status_code == 200
         data = r.get_json()
-        assert data["stats"]["hourlyActivity"][0] == 4
+        assert data["stats"]["hourlyActivity"][expected_hour] == 4
 
     def test_refresh_metadata_requires_settings_password(self, app, client, monkeypatch):
         from app_config.app_config import app_config

--- a/app/web/tests/test_api.py
+++ b/app/web/tests/test_api.py
@@ -685,17 +685,19 @@ class TestTimeline:
             db.session.add(species)
             db.session.flush()
             species_name = species.name
+            # Midday UTC on 2026-03-25 lies in observer-local calendar 2026-03-25 for both UTC
+            # and Europe/Moscow (unlike late evening UTC on 2026-03-24, which is «next day» only in MSK).
             visit = SpeciesVisit(
                 species_id=species.id,
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 15, 0),
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 10, 0),
                 max_simultaneous=1,
             )
             video = Video(
                 processor_version="test",
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 5, 30),
-                video_path="data/recordings/2026/03/24/210500/video.mp4",
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 0, 30),
+                video_path="data/recordings/2026/03/25/140000/video.mp4",
             )
             db.session.add_all([visit, video])
             db.session.flush()
@@ -732,15 +734,15 @@ class TestTimeline:
             db.session.flush()
             visit = SpeciesVisit(
                 species_id=species.id,
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 15, 0),
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 10, 0),
                 max_simultaneous=1,
             )
             video = Video(
                 processor_version="test",
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 5, 30),
-                video_path=f"data/recordings/2026/03/24/210501/dedup{id(app)}.mp4",
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 0, 30),
+                video_path=f"data/recordings/2026/03/25/140001/dedup{id(app)}.mp4",
             )
             db.session.add_all([visit, video])
             db.session.flush()
@@ -798,15 +800,15 @@ class TestTimeline:
             species_name = species.name
             visit = SpeciesVisit(
                 species_id=species.id,
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 15, 0),
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 10, 0),
                 max_simultaneous=1,
             )
             video = Video(
                 processor_version="test",
-                start_time=datetime(2026, 3, 24, 21, 5, 0),
-                end_time=datetime(2026, 3, 24, 21, 5, 30),
-                video_path=f"data/recordings/2026/03/24/210502/scales_{id(app)}.mp4",
+                start_time=datetime(2026, 3, 25, 14, 0, 0),
+                end_time=datetime(2026, 3, 25, 14, 0, 30),
+                video_path=f"data/recordings/2026/03/25/140002/scales_{id(app)}.mp4",
                 scales_weight_delta_kg=0.015,
             )
             db.session.add_all([visit, video])

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,11 +52,12 @@
 | Risk | Description | Recommendation |
 |------|--------------|----------------|
 | ~~**Critical**~~ **Fixed** | `location /data/` with `alias /app/data/` — request `/data/../.env` could read `/app/.env`. | Added check `if ($request_uri ~* "\.\.") { return 403; }` in all nginx configs. |
+| ~~**Critical**~~ **Fixed** | Same broad `/data/` alias exposed the whole volume: e.g. **`/data/db/birdlense.db`**, dataset crops, cache — no HTTP auth. | **Allowlist** in nginx: only `/data/recordings/`, `/data/images/`, `/data/file_test/`; any other `/data/*` → **403** ([#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339)). |
 | **High** | `/data/recordings/` accessible without authentication. Path `YYYY/MM/DD/HHMMSS/video.mp4` is predictable. | Add access check via API with auth or restrict by IP. |
 
 **Mitigations (pick one for production exposure):** (1) **IP allowlist** — more specific `location ^~ /data/recordings/` with `allow`/`deny` (see `app/nginx/examples/recordings_allowlist.conf.snippet` and [DEPLOY_SERVER.md §8](./DEPLOY_SERVER.md)); (2) **no direct nginx media** — reverse proxy only passes `/api/…` and authenticated stream routes; (3) **`auth_request`** to the Hub session endpoint — advanced, not shipped by default.
 
-**Test:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — if vulnerable, returns 200.
+**Tests:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — if vulnerable, returns 200. **`curl -I "http://YOUR_HOST:8085/data/db/birdlense.db"`** — must be **403** (not `application/octet-stream`).
 
 ---
 

--- a/docs/SECURITY.ru.md
+++ b/docs/SECURITY.ru.md
@@ -52,11 +52,12 @@
 | Риск | Описание | Рекомендация |
 |------|----------|--------------|
 | ~~**Критический**~~ **Исправлено** | `location /data/` + `alias` — запрос `/data/../.env`. | Проверка `..` в URI → 403 во всех конфигах nginx. |
+| ~~**Критический**~~ **Исправлено** | Тот же широкий alias отдавал весь volume: **`/data/db/birdlense.db`**, кропы датасета, кэш — без HTTP-auth. | **Allowlist** в nginx: только `/data/recordings/`, `/data/images/`, `/data/file_test/`; остальное под `/data/*` → **403** ([#339](https://github.com/Gfermoto/BirdLense-Hub/issues/339)). |
 | **Высокий** | `/data/recordings/` без аутентификации; предсказуемые пути к `video.mp4`. | Выдача через API с auth или ограничение по IP. |
 
 **Смягчение (на выбор при публичном доступе):** (1) **allowlist по IP** — отдельный `location ^~ /data/recordings/` с `allow`/`deny` (пример `app/nginx/examples/recordings_allowlist.conf.snippet`, [DEPLOY_SERVER.ru.md §8](./DEPLOY_SERVER.ru.md)); (2) **без прямой раздачи медиа** — снаружи только reverse proxy на `/api/…` и авторизованные stream-роуты; (3) **`auth_request`** к сессии Hub — сложнее, в образ по умолчанию не входит.
 
-**Проверка:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — при уязвимости будет 200.
+**Проверки:** `curl -I "http://YOUR_HOST:8085/data/../.env"` — при уязвимости будет 200. **`curl -I "http://YOUR_HOST:8085/data/db/birdlense.db"`** — должно быть **403** (не `application/octet-stream`).
 
 ---
 


### PR DESCRIPTION
Синхронизация `main` с `dev`: nginx allowlist /data (#339), тесты processor_runtime_stats + миграция 004 комментарий (#340), CI catalog audit, правки web tests/observer_time.

После merge ключевые `Closes #…` из прошлых PR смогут закрыть issues на default branch.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Security**
  * Ограничен доступ к файлам через веб-сервер: разрешены только `/data/recordings/`, `/data/images/` и `/data/file_test/`. Все остальные пути под `/data/` теперь возвращают ошибку 403, предотвращая доступ к базам данных и кешу.

* **Bug Fixes**
  * Улучшена обработка ошибок при работе с часовыми поясами.
  * Исправлена обработка больших значений счётчиков и отрицательных измерений времени отклика.

* **Documentation**
  * Обновлена документация по безопасности с описанием защиты от несанкционированного доступа к файлам.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->